### PR TITLE
Make large interests square title/link uppercase; fix template error

### DIFF
--- a/src/components/interests/_interests.scss
+++ b/src/components/interests/_interests.scss
@@ -106,7 +106,6 @@ $desktop-size: 1140px;
               font-size: 4rem;
               line-height: 1;
               text-align: left;
-              text-transform: none;
             }
           }
         }

--- a/src/components/interests/interests.hbs
+++ b/src/components/interests/interests.hbs
@@ -4,7 +4,7 @@
 
     <section class="interests__cards interests__cards--{{ card_count }}">
       {{#each interests.cards}}
-        <a class="interests__card interests__card--{{ num }}" href="{{ url }}">
+        <a class="interests__card interests__card--{{ order }}" href="{{ url }}">
           <div class="interests__card--inner" style="background-image: url( {{ src }} )">
             <span class="interests__card__link">
               {{ interest }}


### PR DESCRIPTION
Per this card: https://trello.com/c/Fd8sx3sH/257-1-big-tile-in-interests-component-should-show-title-in-uppercase. 

Also discovered that the card order # wasn't being added to the class because of an incorrect variable name. Wasn't affecting the component functionality, but I went ahead and made the fix.

<img width="725" alt="screen shot 2015-08-05 at 5 50 21 pm" src="https://cloud.githubusercontent.com/assets/3247835/9099917/12dec31a-3b9b-11e5-915f-ce18e9f4ad0e.png">
