### PR TITLE
Wrap article image in anchor tag

### DIFF
--- a/src/components/articles/articles.hbs
+++ b/src/components/articles/articles.hbs
@@ -22,7 +22,9 @@
         </a>
       </div>
       {{#if src}}
-        <div class="article__imagery" style="background-image: url({{src}})"></div>
+        <a href="{{url}}">
+          <div class="article__imagery" style="background-image: url({{src}})"></div>
+        </a>
       {{/if}}
     </article>
   {{/each}}


### PR DESCRIPTION
Makes the article image clickable to the article. Epic.