### PR TITLE
Integrate interactive maps

### DIFF
--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -12,7 +12,7 @@ let MapActions = {
     $.ajax({
       url: "/" + place + "/map.json"
     }).done((results) => {
-      Arkham.trigger("place.fetched", results);
+      Arkham.trigger("place.fetched", results.map_data);
     }).error((results) => {
       let error = {
         message: "There was an error fetching " + data.placeTitled,

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -53,6 +53,54 @@ let MapActions = {
 
   customPanel: (data) => {
     Arkham.trigger("custompanel.opened", data);
+  },
+
+  fetchSponsors: (data) => {
+    var x = JSON.stringify({
+      placements: [
+        {
+          divName: "sponsored",
+          networkId: 9807,
+          siteId: 316543,
+          adTypes: [ 43 ],
+          eventIds: [31, 32],
+          campaignId: 284161,
+          properties: {
+            "place": "asia"
+          }
+        },
+        {
+          divName: "sponsored1",
+          networkId: 9807,
+          siteId: 316543,
+          adTypes: [ 43 ],
+          eventIds: [31, 32],
+          campaignId: 284161,
+          properties: {
+            "place": "asia"
+          }
+        }
+      ]
+    });
+  $.ajax({
+    url: "http://engine.adzerk.net/api/v2",
+    method: "POST",
+    contentType: "application/json",
+    data: x,
+    success: function(response) {
+      var set = {title: "Sponsored", items: [] };
+      for(var decision in response.decisions) {
+        var poi = JSON.parse(response.decisions[decision].contents[0].body);
+          set.items.push(poi);
+      }
+      Arkham.trigger("sponsor.fetched", set)
+    },
+    error: function() {
+      console.log('fail"')
+    }
+  });
+
+
   }
 
 };

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -56,7 +56,7 @@ let MapActions = {
   },
 
   fetchSponsors: (data) => {
-    var x = JSON.stringify({
+    let x = JSON.stringify({
       placements: [
         {
           divName: "sponsored",
@@ -88,15 +88,15 @@ let MapActions = {
     contentType: "application/json",
     data: x,
     success: function(response) {
-      var set = {title: "Sponsored", items: [] };
-      for(var decision in response.decisions) {
-        var poi = JSON.parse(response.decisions[decision].contents[0].body);
+      let set = {title: "Sponsored", items: [] };
+      for(let decision in response.decisions) {
+        let poi = JSON.parse(response.decisions[decision].contents[0].body);
           set.items.push(poi);
       }
       Arkham.trigger("sponsor.fetched", set)
     },
     error: function() {
-      console.log('fail"')
+      console.log("fail")
     }
   });
 

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -49,6 +49,10 @@ let MapActions = {
 
   initMap: () => {
     Arkham.trigger("map.init");
+  },
+
+  customPanel: (data) => {
+    Arkham.trigger("custompanel.opened", data);
   }
 
 };

--- a/src/components/map/api.js
+++ b/src/components/map/api.js
@@ -36,8 +36,8 @@ let MapAPI = {
    * Remove all map markers
    */
   clear: function() {
-    // empty map of all pins
     this.mapProvider.removeMarkers();
+    this.mapProvider.removePopup();
   }
 
 };

--- a/src/components/map/api.js
+++ b/src/components/map/api.js
@@ -31,7 +31,6 @@ let MapAPI = {
    */
   plot: function(pois) {
     this.mapProvider.addMarkers(pois);
-    // clear map and replot with new pins
   },
   /**
    * Remove all map markers

--- a/src/components/map/interactive-map.js
+++ b/src/components/map/interactive-map.js
@@ -19,6 +19,10 @@ class InteractiveMap extends Component {
     Arkham.on("view.changed", () => {
       this.changeView();
     });
+
+    Arkham.on("place.fetched", () => {
+      this.changeView();
+    });
   }
 
   launch() {
@@ -34,10 +38,6 @@ class InteractiveMap extends Component {
     let pois = state.sets[state.activeSetIndex].items;
 
     MapAPI.redraw(pois);
-  }
-
-  isFetching() {
-    MapAPI.clear();
   }
 
   hasFetched() {

--- a/src/components/map/interactive-map.js
+++ b/src/components/map/interactive-map.js
@@ -26,7 +26,7 @@ class InteractiveMap extends Component {
   }
 
   launch() {
-    MapAPI.launch(this.$el.find(".map-container"));
+    MapAPI.launch(this.$el);
   }
 
   kill() {

--- a/src/components/map/map.hbs
+++ b/src/components/map/map.hbs
@@ -1,10 +1,2 @@
 <div class="map_holder" data-lp-initial-data="{{initial.to_json}}">
 </div>
-
-<!--
-  data-poi="2"
-  data-place="asia" // slug
-  data-view="1"
-  data-pintype="poi"
-  data-plaectype="place"
- -->

--- a/src/components/map/map.scss
+++ b/src/components/map/map.scss
@@ -18,6 +18,7 @@
   }
 }
 
+// Needs an :after fix
 .map_holder {
   position: fixed;
   top: 0;
@@ -26,13 +27,14 @@
   left: 0;
   height: 100vh;
   width: 100vw;
-  z-index: 200;
+
   background: rgba(0,0,0,.5);
-  transform: translate(100%);
-  transition: transform .4s ease-in-out;
+  opacity: 0;
+  transition: opacity .2s ease-in-out;
 
   &.open {
-    transform: translate(0);
+    opacity: 1;
+    z-index: 200;
   }
 }
 
@@ -49,9 +51,15 @@
 
 
 .map {
-  width: 94vw;
-  transform: translate(6vw);
+  width: 100%;
   height: 100%;
+  transform: translate(100%);
+  transition: transform .4s ease-in-out;
+  // transition-delay: .2s;
+
+  &.open {
+    transform: translate(0);
+  }
 
   .flexbox & {
     display: flex;
@@ -61,7 +69,7 @@
 }
 
 .map-container {
-  width: 100 - $sidebarwidth;
+  width: 100 - $sidebarwidth - $closeWidth;
   height: 100%;
   background: rgba(255,255,255,.5);
 
@@ -85,5 +93,12 @@
 }
 
 .close-map {
+  width: 100px;
 
+  .flexbox & {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    flex: 0 0 auto;
+  }
 }

--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -26,7 +26,7 @@ class MapComponent extends Component {
       this.close();
     });
 
-    // MapActions.fetchSponsors();
+    MapActions.fetchSponsors();
   }
 
   open() {

--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -2,7 +2,6 @@ import { Component } from "../../core/bane";
 import React from "react";
 import MainView from "./views/main.jsx";
 import MapActions from "./actions";
-import InteractiveMap from "./interactive-map";
 import Arkham from "../../core/arkham"
 
 class MapComponent extends Component {
@@ -16,11 +15,6 @@ class MapComponent extends Component {
     MapActions.setState(originalState.data);
 
     React.render(<MainView />, document.querySelector(this.el));
-
-    this.interactiveMap = new InteractiveMap({
-      el: this.el
-    });
-    MapActions.initMap();
 
     Arkham.on("map.closed", () => {
       this.close();

--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -3,12 +3,15 @@ import React from "react";
 import MainView from "./views/main.jsx";
 import MapActions from "./actions";
 import InteractiveMap from "./interactive-map";
+import Arkham from "../../core/arkham"
 
 class MapComponent extends Component {
 
   initialize(props) {
     let originalState = this.getInitialState();
     this.el = props.el;
+
+    let fullscreen = $(this.el).parent().data("fullscreen");
 
     MapActions.setState(originalState.data);
 
@@ -18,6 +21,12 @@ class MapComponent extends Component {
       el: this.el
     });
     MapActions.initMap();
+
+    Arkham.on("map.closed", () => {
+      this.close();
+    });
+
+    // MapActions.fetchSponsors();
   }
 
   open() {
@@ -29,7 +38,6 @@ class MapComponent extends Component {
   close() {
     $("html,body").removeClass("noscroll");
     this.$el.removeClass("open");
-    MapActions.close();
   }
 
 }

--- a/src/components/map/mapbox/index.js
+++ b/src/components/map/mapbox/index.js
@@ -3,7 +3,7 @@ import MapboxMarkerSet from "./markerset";
 import "mapbox.js";
 
 let L = window.L;
-let mapID = "lonelyplanet.jf08j2nj";
+let mapID = "lonelyplanet.04cf7895";
 
 L.mapbox.accessToken = "pk.eyJ1IjoibG9uZWx5cGxhbmV0IiwiYSI6Imh1ODUtdUEifQ.OLLon0V6rcoTyayXzzUzsg";
 

--- a/src/components/map/mapbox/index.js
+++ b/src/components/map/mapbox/index.js
@@ -26,6 +26,7 @@ class MapProvider extends Component {
 
   addMarkers(pois) {
     this.markers = new MapboxMarkerSet({
+      el: this.el,
       map: this.map,
       layer: this.layer,
       pois: pois

--- a/src/components/map/mapbox/index.js
+++ b/src/components/map/mapbox/index.js
@@ -36,6 +36,10 @@ class MapProvider extends Component {
     delete this.markers;
   }
 
+  removePopup() {
+    this.map.closePopup();
+  }
+
 }
 
 export default MapProvider;

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -64,12 +64,12 @@ class MarkerSet extends Component {
     for (let i = 0, l = this.pois.length; i < l; i++) {
       let geo = this.pois[i].geo;
 
-      if(geo.geometry.coordinates[0] === null || geo.geometry.coordinates[0] === null) {
-        geo.geometry.coordinates = [0, 0];
+      if(geo.geometry.coordinates[0] === null || geo.geometry.coordinates[1] === null) {
+        continue
+      } else {
+        geo.properties.index = i;
+        geojson.features.push(geo);
       }
-
-      geo.properties.index = i;
-      geojson.features.push(geo);
     }
 
     this.layer.setGeoJSON(geojson);

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -1,7 +1,6 @@
 import { Component } from "../../../core/bane";
 import Arkham from "../../../core/arkham";
 import MapActions from "../actions";
-// import PinTemplate from "./pin.html.hbs";
 import MapState from "../state";
 import React from "react";
 import Pin from "../views/pin.jsx";

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -88,9 +88,6 @@ class MarkerSet extends Component {
   _createIcon(layer) {
     let state = MapState.getState();
     let pin = state.sets[state.activeSetIndex].items[layer.feature.properties.index];
-
-    pin.onMap = true;
-
     let poi = { pin: pin };
     let markup = React.renderToStaticMarkup(React.createElement(Pin, poi));
     // let pin = PinTemplate(layer.feature.properties);

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -12,6 +12,10 @@ let L = window.L;
 class MarkerSet extends Component {
 
   initialize({ pois, map, layer }) {
+    this.events = {
+      "click .pin": "_poiClick"
+    };
+
     this.pois = pois;
     this.map = map;
     this.layer = layer;
@@ -105,9 +109,6 @@ class MarkerSet extends Component {
     })
     .on("mouseout", function(e) {
       _this._poiUnhover(e.layer);
-    })
-    .on("click", function(e) {
-      _this._poiClick(e.layer);
     });
   }
 
@@ -130,13 +131,14 @@ class MarkerSet extends Component {
 
   // A layer argument is passed in, but it is not used
   // The defined argument has been removed to pass ESLint
-  _poiUnhover() {
+  _poiUnhover(layer) {
     // Use if needed
+    this.activeLayer = layer;
   }
 
-  _poiClick(layer) {
+  _poiClick(event) {
     // figure out if a PLACE or a POI
-    MapActions.poiOpen(layer.feature.properties);
+    MapActions.poiOpen(this.activeLayer.feature.properties);
   }
 
   _fixzIndex(currentLayer) {

--- a/src/components/map/mapbox/pin.html.hbs
+++ b/src/components/map/mapbox/pin.html.hbs
@@ -1,9 +1,0 @@
-<div class='location--image'>
-  <img data-src='http://localhost:8080/images/{{image}}' alt='placeholder images' />
-</div>
-<div class='location--details'>
-  <div class='location--header'>
-    <h2 class='location--title'>{{name}}</h2>
-  </div>
-</div>
-<div class="location--index">{{@index}}</div>

--- a/src/components/map/state.js
+++ b/src/components/map/state.js
@@ -110,4 +110,9 @@ Arkham.on("custompanel.opened", (data) => {
   MapState.emitChange();
 });
 
+Arkham.on("sponsor.fetched", (data) => {
+  state.sets.push(data);
+  MapState.emitChange();
+});
+
 export default MapState;

--- a/src/components/map/state.js
+++ b/src/components/map/state.js
@@ -15,7 +15,8 @@ let state = {
   currentLocation: {},
   sets: [],
   error: null,
-  hoveredPin: 0
+  hoveredPin: 0,
+  customPanel: ""
 };
 
 let MapState = assign({
@@ -49,6 +50,7 @@ Arkham.on("map.closed", () => {
 
 Arkham.on("view.changed", (data) => {
   state.activeSetIndex = data.view;
+  state.customPanel = "";
   MapState.emitChange();
 });
 
@@ -99,6 +101,12 @@ Arkham.on("state.setinitial", (data) => {
 
 Arkham.on("poi.hover", (data) => {
   state.hoveredPin = data.pin;
+  MapState.emitChange();
+});
+
+Arkham.on("custompanel.opened", (data) => {
+  state.activeSetIndex = data.view;
+  state.customPanel = data.panel;
   MapState.emitChange();
 });
 

--- a/src/components/map/vars.scss
+++ b/src/components/map/vars.scss
@@ -4,4 +4,5 @@ $orderwidth: 60px;
 $disabled: #CBD9E4;
 $togglewidth: 10vw;
 $sidebarwidth: 470px;
+$closeWidth: 100px;
 $pinsize: 20px;

--- a/src/components/map/views/about-panel.jsx
+++ b/src/components/map/views/about-panel.jsx
@@ -1,16 +1,13 @@
-var React = require("react");
-var Item = require("./item.jsx");
+import React from "react";
+import Item from "./item.jsx";
 
-var PanelView = React.createClass({
+export default class AboutPanel extends React.Component {
 
-  render: function() {
-    var description = this.props.location.description;
+  render() {
+    let description = this.props.location.description;
     return (
       <div className="panel" dangerouslySetInnerHTML={{__html: description}}>
       </div>
     )
   }
-
-});
-
-module.exports = PanelView;
+}

--- a/src/components/map/views/about-panel.jsx
+++ b/src/components/map/views/about-panel.jsx
@@ -1,0 +1,16 @@
+var React = require("react");
+var Item = require("./item.jsx");
+
+var PanelView = React.createClass({
+
+  render: function() {
+    var description = this.props.location.description;
+    return (
+      <div className="panel" dangerouslySetInnerHTML={{__html: description}}>
+      </div>
+    )
+  }
+
+});
+
+module.exports = PanelView;

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -10,17 +10,19 @@ export default class ItemView extends React.Component {
   render() {
     let item = this.props.item;
     let classString = "place ";
-
+    let imageSrc = "http://placehold.it/350x150";
     if (item.onMap) {
       classString += "pin";
     } else {
       classString += "list";
     }
-
+    if (item.geo.properties.image) {
+      imageSrc = "http://images-resrc.staticlp.com/S=H150/" + item.geo.properties.image;
+    }
     return (
       <div className={classString} onClick={this.clickItem.bind(this)}>
         <div className="place__pic">
-          <img src="http://www.luxuo.com/wp-content/uploads/2011/07/bangkok-temple.jpg" />
+          <img src={imageSrc} />
         </div>
         <div className="place__order">{item.i+1}</div>
         <div className="place__text">

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -6,8 +6,6 @@ import MapActions from "../actions";
  * @type {*|Function}x
  */
 export default class ItemView extends React.Component {
-
-<<<<<<< HEAD
   render() {
     let item = this.props.item;
     let title = item.title;
@@ -19,7 +17,7 @@ export default class ItemView extends React.Component {
       classString += "list";
     }
     if (item.geo.properties.image) {
-      imageSrc = "http://images-resrc.staticlp.com/S=H150=/" + item.geo.properties.image;
+      imageSrc = "http://images-resrc.staticlp.com/S=H150/" + item.geo.properties.image;
     }
     if (title.length > 35) {
       title = title.substr(0, 34) + "...";
@@ -40,10 +38,11 @@ export default class ItemView extends React.Component {
 
   clickItem() {
     let props = this.props;
-
-     MapActions.poiOpen({ index: props.item.i });
-    // TODO: Swap to fix the map loading issue
-    //MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title });
+    console.log(props);
+    if(props.item.item_type === "Place") {
+      MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title });
+    } else {
+      MapActions.poiOpen({ index: props.item.i });
+    }
   }
-
 }

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -7,8 +7,10 @@ import MapActions from "../actions";
  */
 export default class ItemView extends React.Component {
 
+<<<<<<< HEAD
   render() {
     let item = this.props.item;
+    let title = item.title;
     let classString = "place ";
     let imageSrc = "http://placehold.it/350x150";
     if (item.onMap) {
@@ -17,7 +19,10 @@ export default class ItemView extends React.Component {
       classString += "list";
     }
     if (item.geo.properties.image) {
-      imageSrc = "http://images-resrc.staticlp.com/S=H150/" + item.geo.properties.image;
+      imageSrc = "http://images-resrc.staticlp.com/S=H150=/" + item.geo.properties.image;
+    }
+    if (title.length > 35) {
+      title = title.substr(0, 34) + "...";
     }
     return (
       <div className={classString} onClick={this.clickItem.bind(this)}>
@@ -26,7 +31,7 @@ export default class ItemView extends React.Component {
         </div>
         <div className="place__order">{item.i+1}</div>
         <div className="place__text">
-          <div className="title">{item.title}</div>
+          <div className="title">{title}</div>
           <div className="subtitle">{item.subtitle}</div>
         </div>
       </div>

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -38,7 +38,6 @@ export default class ItemView extends React.Component {
 
   clickItem() {
     let props = this.props;
-    console.log(props);
     if(props.item.item_type === "Place") {
       MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title });
     } else {

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -46,7 +46,7 @@ export default class MainView extends React.Component {
       if (this.state.isDetail) {
         sidebar = <SidebarDetails poi={this.state.sets[this.state.activeSetIndex].items[this.state.poi]} />
       } else {
-        sidebar = <Sidebar location={this.state.currentLocation} sets={this.state.sets} activeSetIndex={this.state.activeSetIndex} />
+        sidebar = <Sidebar location={this.state.currentLocation} sets={this.state.sets} activeSetIndex={this.state.activeSetIndex} customPanel={this.state.customPanel}/>
       }
     }
 

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -5,6 +5,7 @@ import SidebarDetails from "./sidebar-details.jsx";
 import Map from "./map.jsx";
 import Alert from "./alert.jsx";
 import MapState from "../state";
+import MapActions from "../actions";
 
 let getMapState = function(props) {
   return MapState.getState();
@@ -64,7 +65,7 @@ export default class MainView extends React.Component {
 
   // TODO: Trigger an action here, try not to call dispatcher directly
   closeMap() {
-    Arkham.trigger("map.closed");
+    MapActions.mapClose()
   }
 
 }

--- a/src/components/map/views/map.jsx
+++ b/src/components/map/views/map.jsx
@@ -1,14 +1,20 @@
 import React from "react";
 import MapActions from "../actions";
+import InteractiveMap from "../interactive-map";
 
 /**
  * The main component for the map view
  */
 export default class MapView extends React.Component {
-
+  componentDidMount() {
+    this.interactiveMap = new InteractiveMap({
+      el: this.refs.map.getDOMNode()
+    });
+    MapActions.initMap();
+  }
   render() {
     return (
-      <div className="map-container">Map goes here</div>
+      <div ref="map" className="map-container">Map goes here</div>
     )
   }
 

--- a/src/components/map/views/panel.jsx
+++ b/src/components/map/views/panel.jsx
@@ -9,6 +9,7 @@ export default class PanelView extends React.Component {
   render() {
     let items = this.props.set.items.map((item, i) => {
       item.i = i;
+      item.onMap = false;
       return (
         <Item item={item}/>
       )

--- a/src/components/map/views/pin.jsx
+++ b/src/components/map/views/pin.jsx
@@ -6,7 +6,7 @@ export default class PinView extends React.Component {
 
   render() {
     let pin = this.props.pin;
-
+    pin.onMap = true;
     return (
       <Item item={pin} />
     );

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -24,8 +24,8 @@ export default class SidebarView extends React.Component {
 
     if (location.description.length > 0) {
       tabCount++;
-      var isActive = tabCount === activeSetIndex ? true : false;
-      var aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" />
+      let isActive = tabCount === activeSetIndex ? true : false;
+      let aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" />
       tabs.push(aboutTab);
     }
 
@@ -35,7 +35,7 @@ export default class SidebarView extends React.Component {
       if( this.props.customPanel === "about" ) {
         panelContent = <AboutPanel location={location} />;
       } else {
-        var activePanel = this.props.sets[this.props.activeSetIndex];
+        let activePanel = this.props.sets[this.props.activeSetIndex];
         panelContent = <Panel set={activePanel} />;
       }
     }

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import Tab from "./tab.jsx";
 import Panel from "./panel.jsx";
 import MapActions from "../actions";
+import AboutPanel from "./about-panel.jsx"
 
 /**
  * Sidebar view that sets up main tabs
@@ -23,16 +24,20 @@ export default class SidebarView extends React.Component {
 
     if (location.description.length > 0) {
       tabCount++;
-      let isActive = tabCount === activeSetIndex ? true : false;
-      let aboutTab = <Tab name="About" active={isActive} i={tabCount} />
+      var isActive = tabCount === activeSetIndex ? true : false;
+      var aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" />
       tabs.push(aboutTab);
     }
 
     if (this.props.sets.length < 1) {
       panelContent =  <div className="no-content" dangerouslySetInnerHTML={{__html: location.description}}></div>;
     } else {
-      let activePanel = this.props.sets[this.props.activeSetIndex];
-      panelContent = <Panel set={activePanel} />;
+      if( this.props.customPanel === "about" ) {
+        panelContent = <AboutPanel location={location} />;
+      } else {
+        var activePanel = this.props.sets[this.props.activeSetIndex];
+        panelContent = <Panel set={activePanel} />;
+      }
     }
 
     return (

--- a/src/components/map/views/tab.jsx
+++ b/src/components/map/views/tab.jsx
@@ -18,7 +18,11 @@ export default class TabView extends React.Component {
 
   tabClick() {
     let props = this.props;
-    MapActions.viewChange({ view: props.i })
+    if (props.customPanel) {
+      MapActions.customPanel({ panel: props.customPanel, view: props.i })
+    } else {
+      MapActions.viewChange({ view: props.i })
+    }
   }
 }
 

--- a/src/components/map/views/tab.jsx
+++ b/src/components/map/views/tab.jsx
@@ -10,7 +10,7 @@ export default class TabView extends React.Component {
     let title = this.props.name;
     let isActive = this.props.active ? "tab active" : "tab";
     return (
-      <div className={isActive} onClick={this.tabClick}>
+      <div className={isActive} onClick={this.tabClick.bind(this)}>
         {title}
       </div>
     )

--- a/src/components/map_static/index.js
+++ b/src/components/map_static/index.js
@@ -1,10 +1,11 @@
 require("./_map_static.scss");
 
 let mapLoaded = false;
-$(".js-open-map").on("click", function() {
+let $mapButton = $(".js-open-map");
+$mapButton.on("click", function() {
   if (!mapLoaded) {
     require([
-      "../map/map_component"
+      "../map/index"
     ], (MapComponent) => {
       let map = new MapComponent({
         el: ".map_holder"
@@ -13,3 +14,7 @@ $(".js-open-map").on("click", function() {
     });
   }
 });
+
+if (window.location.href.indexOf("/map") > -1) {
+  $mapButton.trigger("click");
+}

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -248,8 +248,6 @@
     opacity: 0;
     transition: opacity $animation-speed-ui*2 ease-in-out;
 
-
-
     @media (min-width: $min-720) {
       font-size: 30px;
     }


### PR DESCRIPTION
This gets a working MVP of an interactive map working in all templates. You can now open a map with a button click (located right under the static map for the time being), and click tabs for cities. experiences, sponsored sites, and the "about" content. Clicking a city in the sidebar loads a new map.

Pairs with the DN PR: https://github.com/lonelyplanet/destinations-next/pull/286
