### PR TITLE
Add id to maps container for sub-nav link

### DIFF
--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,4 +1,4 @@
-<article class="map_static">
+<article id="maps" class="map_static">
   <div class="map_static__container">
     <img class="map_static__img" src="{{static_map.map_url}}" alt="Map of {{place.name}}">
   </div>


### PR DESCRIPTION
Massive PR. Allows sub-nav to find and scroll to the maps component