### PR TITLE
Limit static map height

### DIFF
--- a/src/components/map_static/_map_static.scss
+++ b/src/components/map_static/_map_static.scss
@@ -12,6 +12,7 @@
 
   &__container {
     display: none;
+    text-align: center;
 
     @media (min-width: $min-960) {
       display: block;
@@ -22,5 +23,11 @@
       width: 100%;
       padding: ($gutter*13.2) 0;
     }
+  }
+
+  &__btn {
+    @include button();
+
+    position: absolute;
   }
 }

--- a/src/components/map_static/_map_static.scss
+++ b/src/components/map_static/_map_static.scss
@@ -1,7 +1,5 @@
 @import "../../../sass/webpack_deps";
 
-
-
 .map_static {
   @media (max-width: $max-960) {
     margin: 0 ($gutter*0.5);
@@ -9,19 +7,7 @@
     max-width: $max-width;
     height: .1rem;
 
-    background: $color-border;;
-
-    @media (min-width: $min-720){
-      margin: 0 ($gutter*1);
-    }
-
-    @media (min-width: $min-1080){
-      margin: 0 ($gutter*2);
-    }
-
-    @media (min-width: $min-1290){
-      margin: 0 auto;
-    }
+    background: $color-border;
   }
 
   &__container {
@@ -29,11 +15,12 @@
 
     @media (min-width: $min-960) {
       display: block;
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
+      height: 0;
+      width: 100%;
+      padding: ($gutter*13.2) 0;
     }
   }
-}
-
-.map_static__img {
-  width: 100%;
-  height: auto;
 }

--- a/src/components/map_static/index.js
+++ b/src/components/map_static/index.js
@@ -1,1 +1,15 @@
 require("./_map_static.scss");
+
+let mapLoaded = false;
+$(".js-open-map").on("click", function() {
+  if (!mapLoaded) {
+    require([
+      "../map/map_component"
+    ], (MapComponent) => {
+      let map = new MapComponent({
+        el: ".map_holder"
+      });
+      map.open();
+    });
+  }
+});

--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,5 +1,6 @@
 <article id="maps" class="map_static" >
   <div class="map_static__container" style="background-image: url('{{static_map.map_url}}')">
-    <button class="map_static__btn js-open-map">Open Map</button>
+    {{!-- hide button until ready for preview --}}
+    <button class="map_static__btn js-open-map is-hidden">Open Map</button>
   </div>
 </article>

--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,3 +1,5 @@
 <article id="maps" class="map_static" >
-  <div class="map_static__container" style="background-image: url('{{static_map.map_url}}')"></div>
+  <div class="map_static__container" style="background-image: url('{{static_map.map_url}}')">
+    <button class="map_static__btn js-open-map">Open Map</button>
+  </div>
 </article>

--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,5 +1,3 @@
-<article id="maps" class="map_static">
-  <div class="map_static__container">
-    <img class="map_static__img" src="{{static_map.map_url}}" alt="Map of {{place.name}}">
-  </div>
+<article id="maps" class="map_static" >
+  <div class="map_static__container" style="background-image: url('{{static_map.map_url}}')"></div>
 </article>


### PR DESCRIPTION
Addresses the ever-expanding map size as the screen widens. Now behaves similarly to hotels, where the container height stays static and the background image zooms to fit the container.
Also adds the 'open map' button and moves the logic for triggering a new interactive map said button into the static map