### PR TITLE
Clean up map close animation; Add close icon; first IE9 refactoring

### DIFF
--- a/src/components/map/map.scss
+++ b/src/components/map/map.scss
@@ -30,7 +30,8 @@
 
   background: rgba(0,0,0,.5);
   opacity: 0;
-  transition: opacity .2s ease-in-out;
+  z-index: 200;
+  transition: opacity .5s ease-in-out;
 
   &.open {
     opacity: 1;
@@ -49,13 +50,12 @@
   background: #333;
 }
 
-
 .map {
+  display: block;
   width: 100%;
   height: 100%;
   transform: translate(100%);
   transition: transform .4s ease-in-out;
-  // transition-delay: .2s;
 
   &.open {
     transform: translate(0);
@@ -65,22 +65,17 @@
     display: flex;
     flex-direction: row;
   }
-
 }
 
 .map-container {
-  width: 100 - $sidebarwidth - $closeWidth;
+  width: $mapContainerWidth;
   height: 100%;
   background: rgba(255,255,255,.5);
-
-  .flexbox & {
-    width: auto;
-    flex: 1 1 auto;
-  }
 
   .leaflet-popup-tip-container {
     display: none;
   }
+
   .leaflet-popup-content {
     padding: 0px;
     width: $itemwidth !important;
@@ -93,12 +88,35 @@
 }
 
 .close-map {
-  width: 100px;
+  float: left;
+  z-index: 10000;
 
-  .flexbox & {
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    flex: 0 0 auto;
+  height: $closeButton;
+  width: $closeButton;
+  margin: {
+    top: $closeMargin;
+    left: 5px;
+    right: 5px;
+  }
+  font-size: 2.6rem;
+  line-height: $closeButton;
+  text-align: center;
+
+  // Move 'Close' text out of sight but keep for screen readers
+  text-indent: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+
+  border: none;
+  border-radius: 50%;
+
+  box-shadow: 0 12px 25px rgba(0,0,0,.75);
+  background: #fff;
+
+  cursor: pointer;
+
+  &:before {
+    display: block;
+    text-indent: 0;
   }
 }

--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -59,13 +59,6 @@ $unit: $size / 16;
 
   .sidebar-header {
     background: $lpblue;
-    height: 30vh;
-
-    .flexbox & {
-      height: auto;
-      width: 100%;
-      flex: 0 0 auto;
-    }
 
     h1 {
       margin: 0;
@@ -134,14 +127,8 @@ $unit: $size / 16;
   }
 
   .panel {
-    height: 70vh;
+    height: 80vh;
     overflow: auto;
-
-    .flexbox & {
-      height: auto;
-      width: 100%;
-      flex: 1 1 auto;
-    }
 
     .listing {
       margin: 30px 0 0 30px;

--- a/src/components/map/vars.scss
+++ b/src/components/map/vars.scss
@@ -4,5 +4,7 @@ $orderwidth: 60px;
 $disabled: #CBD9E4;
 $togglewidth: 10vw;
 $sidebarwidth: 470px;
-$closeWidth: 100px;
+$closeButton: 70px;
+$closeMargin: calc(50vh - (#{$closeButton} / 2) );
 $pinsize: 20px;
+$mapContainerWidth: calc(100% - #{$sidebarwidth} - #{$closeButton});

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -55,7 +55,7 @@ export default class MainView extends React.Component {
 
     return (
       <div className={classString}>
-        <div className="close-map" onClick={this.closeMap}>Close</div>
+        <div className="close-map icon-close-small" onClick={this.closeMap}>Close</div>
         <Map pins={activeSet} location={this.state.location} index={this.state.activeIndex} />
         {sidebar}
         <Alert error={this.state.error} />


### PR DESCRIPTION
Makes maps component close more smoothly and adds a proper close button to match the one in masthead. Now displays properly in IE9, too.
<img width="1389" alt="screen shot 2015-08-25 at 8 52 36 am" src="https://cloud.githubusercontent.com/assets/3247835/9468272/5c829ad0-4b06-11e5-9cc3-0c92054e5ad4.png">
