### PR TITLE
Interactive map POI items interactions update

### DIFF
--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -35,13 +35,13 @@ let MapActions = {
     Arkham.trigger("poi.closed");
   },
 
+  // looks like this wasn't being used?
   pinHover: (data) => {
-    Arkham.trigger("poi.hovered", data);
+    Arkham.trigger("map.poihover", data);
   },
 
   mapOpen: () => {
     Arkham.trigger("map.opened");
-    // MapActions.gotoPlace({ place: "asia", placeTitle: "Asia" });
   },
 
   mapClose: () => {

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -35,9 +35,12 @@ let MapActions = {
     Arkham.trigger("poi.closed");
   },
 
-  // looks like this wasn't being used?
   pinHover: (data) => {
     Arkham.trigger("map.poihover", data);
+  },
+
+  itemHighlight: (data) => {
+    Arkham.trigger("item.hovered", data);
   },
 
   mapOpen: () => {

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -50,7 +50,7 @@ class MarkerSet extends Component {
     let l;
 
     this.layer.eachLayer(function(layer) {
-      if (layer.feature.properties.poiIndex === (i + 1)) {
+      if (layer.feature.properties.index === (i)) {
         l = layer;
       }
     });

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -122,7 +122,7 @@ class MarkerSet extends Component {
     this.popup = L.popup({
         closeButton: false,
         keepInView: true,
-        offset: L.point(115, 30)
+        offset: L.point(220, 30)
       })
       .setLatLng(L.latLng(lat, lng))
       .setContent(template)

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -127,6 +127,9 @@ class MarkerSet extends Component {
       .setLatLng(L.latLng(lat, lng))
       .setContent(template)
       .openOn(this.map);
+
+    let poiIndex = layer.feature.properties.index;
+    MapActions.itemHighlight(poiIndex);
   }
 
   // A layer argument is passed in, but it is not used

--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -6,11 +6,15 @@
   cursor: pointer;
   transition: background .3s ease;
 
+  &.is-hovered {
+    background: $hoveredItem;
+  }
+
   &.list {
     margin: 10px 0;
 
     &:hover {
-      background: rgba(#000, .1);
+      background: $hoveredItem;
     }
 
     &:after {

--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -2,12 +2,16 @@
   width: $itemwidth;
   height: 60px;
   background: #fff;
-  // overflow: hidden;
   position: relative;
   cursor: pointer;
+  transition: background .3s ease;
 
   &.list {
     margin: 10px 0;
+
+    &:hover {
+      background: rgba(#000, .1);
+    }
 
     &:after {
       position: absolute;

--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -2,7 +2,7 @@
   width: $itemwidth;
   height: 60px;
   background: #fff;
-  overflow: hidden;
+  // overflow: hidden;
   position: relative;
   cursor: pointer;
 
@@ -23,6 +23,30 @@
 
   &.pin {
     box-shadow: 0 44px 87px -22px #000;
+
+    .place__pointer {
+      position: absolute;
+      left: -9px;
+      top: 20px;
+      width: 0;
+      height: 0;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+      border-right:10px solid #fff;
+      z-index: -1;
+
+      &--shadow {
+        position: absolute;
+        left: -12px;
+        top: 18px;
+        width: 0;
+        height: 0;
+        border-top: 12px solid transparent;
+        border-bottom: 12px solid transparent;
+        border-right:12px solid #C0C0C0;
+        z-index: -2;
+      }
+    }
 
     &:after {
       position: absolute;

--- a/src/components/map/state.js
+++ b/src/components/map/state.js
@@ -16,6 +16,7 @@ let state = {
   sets: [],
   error: null,
   hoveredPin: 0,
+  hoveredItem: null,
   customPanel: ""
 };
 
@@ -102,6 +103,11 @@ Arkham.on("state.setinitial", (data) => {
 
 Arkham.on("poi.hover", (data) => {
   state.hoveredPin = data.pin;
+  MapState.emitChange();
+});
+
+Arkham.on("item.hovered", (data) => {
+  state.hoveredItem = data;
   MapState.emitChange();
 });
 

--- a/src/components/map/vars.scss
+++ b/src/components/map/vars.scss
@@ -8,3 +8,4 @@ $closeButton: 70px;
 $closeMargin: calc(50vh - (#{$closeButton} / 2) );
 $pinsize: 20px;
 $mapContainerWidth: calc(100% - #{$sidebarwidth} - #{$closeButton});
+$hoveredItem: rgba(#000, .1);

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -15,6 +15,9 @@ export default class ItemView extends React.Component {
       classString += "pin";
     } else {
       classString += "list";
+      if (item.highlighted) {
+        classString += " is-hovered";
+      }
     }
     if (item.geo.properties.image) {
       imageSrc = "http://images-resrc.staticlp.com/S=H150/" + item.geo.properties.image;

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -30,6 +30,8 @@ export default class ItemView extends React.Component {
 
     return (
       <div className={classString} onClick={this.clickItem.bind(this)}>
+        <div className="place__pointer"></div>
+        <div className="place__pointer--shadow"></div>
         <div className="place__pic">
           <img src={imageSrc} />
         </div>

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -48,6 +48,7 @@ export default class ItemView extends React.Component {
       MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title });
     } else {
       MapActions.poiOpen({ index: props.item.i });
+      MapActions.pinHover({ poiIndex: props.item.i });
     }
   }
 }

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -47,7 +47,7 @@ export default class MainView extends React.Component {
       if (this.state.isDetail) {
         sidebar = <SidebarDetails poi={this.state.sets[this.state.activeSetIndex].items[this.state.poi]} />
       } else {
-        sidebar = <Sidebar location={this.state.currentLocation} sets={this.state.sets} activeSetIndex={this.state.activeSetIndex} customPanel={this.state.customPanel}/>
+        sidebar = <Sidebar location={this.state.currentLocation} sets={this.state.sets} highlightedPoi={ this.state.hoveredItem } activeSetIndex={this.state.activeSetIndex} customPanel={this.state.customPanel}/>
       }
     }
 

--- a/src/components/map/views/panel.jsx
+++ b/src/components/map/views/panel.jsx
@@ -10,6 +10,7 @@ export default class PanelView extends React.Component {
     let items = this.props.set.items.map((item, i) => {
       item.i = i;
       item.onMap = false;
+      item.highlighted = i === this.props.highlightedPoi;
       return (
         <Item item={item}/>
       )

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -36,7 +36,7 @@ export default class SidebarView extends React.Component {
         panelContent = <AboutPanel location={location} />;
       } else {
         let activePanel = this.props.sets[this.props.activeSetIndex];
-        panelContent = <Panel set={activePanel} />;
+        panelContent = <Panel highlightedPoi={this.props.highlightedPoi} set={activePanel} />;
       }
     }
     let backSlug = `/${location.parent_slug}`;


### PR DESCRIPTION
Updates the connected behavior of the map POI labels and their corresponding sidebar items.
-- Hovering on an item in the sidebar adds a background color to it
-- Clicking on an item in the sidebar opens the POI label in the map
-- Hovering a POI marker on the map highlights the corresponding item in the sidebar
-- Clicking a POI marker on the map loads the description in the sidebar
-- Map POI pop-up are moved to the right of the marker, instead of directly over the marker, for a less disorienting user experience

<img width="887" alt="screen shot 2015-08-31 at 5 01 18 pm" src="https://cloud.githubusercontent.com/assets/3247835/9591612/2f050970-5002-11e5-9ffc-3d29e1ff37ac.png">

     