### PR TITLE
Text and link colors for breadcrumb

### DIFF
--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -137,10 +137,22 @@
     margin-bottom: 10px;
   }
 
-  &__breadcrumb a {
+  &__breadcrumb {
     color: #fff;
-    text-transform: uppercase;
-    position: relative;
+
+    a {
+      color: #fff;
+      text-transform: uppercase;
+      position: relative;
+    }
+  }
+
+  &--no-images &__breadcrumb {
+    color: $font-color;
+
+    a {
+      color: $font-color;
+    }
   }
 
   &__title {


### PR DESCRIPTION
Ensure that breadcrumb links and text (commas) are white for mastheads with images, and black (#333) for mastheads with no images.