### PR TITLE
Updating survival-guide component

### DIFF
--- a/src/components/survival_guide/_survival_guide.scss
+++ b/src/components/survival_guide/_survival_guide.scss
@@ -15,12 +15,23 @@ $mobile-breakpoint: 400;
     margin: 0 auto 2.5rem;
   }
 
-  &__list__link {
+  &__link {
     display: block;
     color: $body-color;
+
+    &:hover,
+    &:focus {
+      .survival-guide__icon {
+        transform: translateY(-.5rem);
+      }
+
+      .survival-guide__title {
+        color: $color-primary;
+      }
+    }
   }
 
-  &__list__item {
+  &__item {
     display: inline-block;
     width: 100%;
     text-align: center;
@@ -49,11 +60,12 @@ $mobile-breakpoint: 400;
     }
   }
 
-  &__list__item__icon {
+  &__icon {
     display: block;
     width: 60px;
     height: 60px;
     margin: 0 auto;
+    transition: transform $animation-speed;
 
     @include respond-to($mobile-breakpoint) {
       width: 80px;
@@ -61,18 +73,19 @@ $mobile-breakpoint: 400;
     }
   }
 
-  &__list__item__title {
+  &__title {
     font-size: 1.8rem;
     font-weight: 700;
     line-height: 1;
     margin-top: 2rem;
+    transition: color $animation-speed;
 
     @include respond-to($mobile-breakpoint) {
       margin-top: 2.8rem;
     }
   }
 
-  &__list__item__blurb {
+  &__blurb {
     width: 90%;
     margin: .5rem auto 0;
     font-size: 1.6rem;

--- a/src/components/survival_guide/survival_guide.hbs
+++ b/src/components/survival_guide/survival_guide.hbs
@@ -1,21 +1,19 @@
 {{#if survival_guide.items}}
 
 <div class="survival-guide" id="survival_guide">
-  <h1 class="survival-guide__heading">{{survival_guide.title}}</h1>
+  <h2 class="survival-guide__heading">{{survival_guide.title}}</h2>
 
-  <div class="survival-guide__inner">
-    <ul class="survival-guide__list">
-      {{#each survival_guide.items}}
-      <li class="survival-guide__list__item">
-        <a class="survival-guide__list__link" href="{{../survival_guide.item_url}}{{slug}}">
-          <i class="survival-guide__list__item__icon icon--{{icon}}-blue" aria-hidden="true" aria-label="{{title}}"></i>
-          <h3 class="survival-guide__list__item__title">{{title}}</h3>
-          <p class="survival-guide__list__item__blurb">{{blurb}}</p>
-        </a>
-      </li>
-      {{/each}}
-    </ul>
-  </div>
+  <ul class="survival-guide__list">
+    {{#each survival_guide.items}}
+    <li class="survival-guide__item">
+      <a class="survival-guide__link" href="{{../survival_guide.item_url}}{{slug}}">
+        <i class="survival-guide__icon icon--{{icon}}-blue" aria-hidden="true" aria-label="{{title}}"></i>
+        <h3 class="survival-guide__title">{{title}}</h3>
+        <p class="survival-guide__blurb">{{blurb}}</p>
+      </a>
+    </li>
+    {{/each}}
+  </ul>
 
   <div class="survival-guide__button-container">
     <a class="survival-guide__more" href="{{survival_guide.see_more_url}}">


### PR DESCRIPTION
- Adding hover, focus states to link and giving style to icon and title
- Changing `h1` to `h2`
- Removing `survival-guide__inner`; there are no styles being applied to it
- Refactoring naming to remove unnecessary `__list` and `__list__item` prefixes