### PR TITLE
Change masthead button text

### DIFF
--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -35,7 +35,7 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
 
         {{#if top_places}}
           <a class="masthead__button js-top-places" >
-            Top {{#if top_places.neighborhoods}}Neighborhoods{{else}}Places{{/if}} in {{place.name}} <i class="icon-chevron-down"></i>
+            Top {{masthead_button_types}} <i class="icon-chevron-down"></i>
           </a>
         {{/if}}
 


### PR DESCRIPTION
Uses `masthead_button_types` from BaseViewModel in DN to show the
place types in the top places.

Examples:
"TOP CITIES", "TOP NEIGHBORHOODS", "TOP COUNTRIES AND CITIES"