### PR TITLE
Updating segment and container mixins

### DIFF
--- a/sass/_base_mixins.scss
+++ b/sass/_base_mixins.scss
@@ -8,17 +8,17 @@
 /// }
 @mixin segment() {
   margin: 0;
-  padding-top: ($gutter*2);
-  padding-bottom: ($gutter*2 - $spacing);
+  padding-top: ($gutter * 2);
+  padding-bottom: ($gutter * 2) - $spacing;
 
-  @media (min-width: $min-720){
-    padding-top: ($gutter*3);
-    padding-bottom: ($gutter*3 - $spacing);
+  @media (min-width: $min-720) {
+    padding-top: ($gutter * 3);
+    padding-bottom: ($gutter * 3) - $spacing;
   }
 
-  @media (min-width: $min-1080){
-    padding-top: ($gutter*4.5);
-    padding-bottom: ($gutter*4.5 - $spacing);
+  @media (min-width: $min-1080) {
+    padding-top: ($gutter * 4.5);
+    padding-bottom: ($gutter * 4.5) - $spacing;
   }
 
   &--grey {
@@ -32,40 +32,38 @@
     content: "";
 
     position: relative;
-    bottom: -$gutter*2 + $spacing;
+    bottom: -($gutter * 2) + $spacing;
 
-    margin-left: ($gutter*0.5);
-    margin-right: ($gutter*0.5);
+    margin-left: ($gutter / 2);
+    margin-right: ($gutter / 2);
 
     max-width: $max-width;
     height: 0;
 
     border-bottom: .1rem solid $color-border;
 
-    @media (min-width: $min-720) {
-      margin-left: ($gutter);
-      margin-right: ($gutter);
+    @media (min-width: $min-480) {
+      margin-left: $gutter;
+      margin-right: $gutter;
 
-      bottom: -$gutter*3 + $spacing;
+      bottom: -($gutter * 3) + $spacing;
     }
 
     @media (min-width: $min-1080) {
-      margin-left: ($gutter*2);
-      margin-right: ($gutter*2);
+      margin-left: ($gutter * 2);
+      margin-right: ($gutter * 2);
 
-      bottom: -$gutter*3.5 + $spacing;
+      bottom: -($gutter * 3.5) + $spacing;
     }
 
-    @media (min-width: $min-1290) {
+    @media (min-width: #{strip-units(($max-width + ($gutter * 4)) * .625)}em) {
       margin-left: auto;
       margin-right: auto;
-
-      max-width: $max-width - $gutter * 4;
     }
   }
 
   &--border-bottom:last-of-type:after {
-    border: 0;
+    border-bottom: 0;
   }
 }
 
@@ -77,24 +75,30 @@
 @mixin container() {
   margin-left: auto;
   margin-right: auto;
-
-  padding-left: ($gutter/2);
-  padding-right: ($gutter/2);
-
   max-width: $max-width;
 
-  @media (min-width: $min-480){
-    padding-left: $gutter;
-    padding-right: $gutter;
+  @media (max-width: $max-480) {
+    padding-left: ($gutter / 2);
+    padding-right: ($gutter / 2);
   }
 
-  @media (min-width: $min-1080){
-    padding-left: $gutter*2;
-    padding-right: $gutter*2;
+  @media (min-width: $min-480) {
+    margin-left: $gutter;
+    margin-right: $gutter;
+  }
+
+  @media (min-width: $min-1080) {
+    margin-left: ($gutter * 2);
+    margin-right: ($gutter * 2);
+  }
+
+  @media (min-width: #{strip-units(($max-width + ($gutter * 4)) * .625)}em) {
+    margin-left: auto;
+    margin-right: auto;
   }
 
   &--slim {
-    max-width: $max-width - 12rem - ($gutter*2);
+    max-width: $max-width - 12rem - ($gutter * 2);
   }
 
   &--narrow {
@@ -102,6 +106,6 @@
   }
 
   &--half {
-    max-width: $max-width/2;
+    max-width: ($max-width / 2);
   }
 }


### PR DESCRIPTION
- Changing `padding` to `margin` on container so that padding does not subtract from actual width; this allows the the container to reach the max 1290 like it should, rather than 1170 (1290 - 120px padding)
- Changing media queries on segment to match those of container; removing 1170px max-width