### PR TITLE
Center the map open btn more better

### DIFF
--- a/src/components/map_static/_map_static.scss
+++ b/src/components/map_static/_map_static.scss
@@ -30,11 +30,14 @@
   }
 
   &__btn {
+    $btnWidth: 268px;
+
     @include button();
 
     position: absolute;
     bottom: 38px;
-    margin-left: calc(50% - 134px);
+    width: $btnWidth;
+    margin-left: calc(50% - #{ $btnWidth / 2 });
     letter-spacing: 0.05em;
     padding-bottom: 1.8rem;
 

--- a/src/components/map_static/_map_static.scss
+++ b/src/components/map_static/_map_static.scss
@@ -34,7 +34,7 @@
 
     position: absolute;
     bottom: 38px;
-    margin-left: calc(50% - 62px);
+    margin-left: calc(50% - 134px);
     letter-spacing: 0.05em;
     padding-bottom: 1.8rem;
 


### PR DESCRIPTION
Sets a specific btn width that can be divided by 2 to center properly.