### PR TITLE
Fixing layout issues with map sidebar

### DIFF
--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -94,7 +94,9 @@
     height: 100%;
     width: $image-width;
     overflow: hidden;
-    position: relative;
+    position: absolute;
+    top: 0;
+    left: 0;
 
     img {
       position: absolute;
@@ -145,10 +147,8 @@
 
   &__text {
     position: absolute;
-    right: 0;
     top: 50%;
     transform: translate(0, -50%);
-    padding-right: 1rem;
 
     .subtitle {
       color: $footer-bottom-link-color;
@@ -159,11 +159,15 @@
 
     .list & {
       width: ($item-width-list - $image-width - $gutter);
+      padding-right: 1rem;
+      left: 10.7rem;
     }
 
     .pin & {
       width: ($item-width-pin - $image-width - $gutter);
       word-spacing: -.1em;
+      padding-right: $gutter;
+      right: 0;
     }
   }
 }

--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -37,21 +37,14 @@ $unit: $size / 16;
 }
 
 .sidebar {
-  display: block;
   position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
-  background: #fff;
+  background-color: #fff;
   width: $sidebar-width;
   overflow: hidden;
-
-  .flexbox & {
-    display: flex;
-    flex-direction: column;
-    position: relative;
-    flex: 0 0 auto;
-  }
+  height: 100vh;
 
   .no-content {
     padding: $gutter;
@@ -59,6 +52,7 @@ $unit: $size / 16;
 
   .sidebar__header {
     background-color: $color-blue;
+    height: $sidebar-header-height;
     padding: 1.9rem $gutter .5rem;
 
     .details {
@@ -148,13 +142,13 @@ $unit: $size / 16;
   }
 
   .panel {
-    height: 87vh;
+    height: calc(100% - #{$sidebar-header-height});
     overflow: auto;
 
     .listing {
       position: relative;
       width: (($sidebar-width - ($gutter * 2)) / $sidebar-width) * 100%;
-      margin: $gutter auto 0;
+      margin: $gutter auto;
       border-top: .1rem solid $divider-color;
     }
 

--- a/src/components/map/vars.scss
+++ b/src/components/map/vars.scss
@@ -5,6 +5,7 @@ $order-width: 6rem;
 $disabled: #cbd9e4;
 $toggle-width: 10vw;
 $sidebar-width: 47rem;
+$sidebar-header-height: 16.9rem;
 $close-button: 7rem;
 $close-margin: calc(50vh - (#{$close-button} / 2));
 $pinsize: 2rem;


### PR DESCRIPTION
- "Close map and explore" shouldn't cover part of the text
- The tabs don't look well in Chrome