### PR TITLE
Improving accuracy and performance of sub nav scrollspy

### DIFF
--- a/src/components/articles/articles.hbs
+++ b/src/components/articles/articles.hbs
@@ -1,4 +1,4 @@
-<article id="articles" class="articles">
+<article class="articles">
   <div class="tabs">
     <ul class="tabs__links">
       <li><a href="#articles-top">{{articles_title}}</a></li>

--- a/src/components/food_and_drink/food_and_drink.hbs
+++ b/src/components/food_and_drink/food_and_drink.hbs
@@ -1,6 +1,6 @@
 {{#if food_and_drink}}
 
-<article id="food-and-drink" class="food-and-drink">
+<article class="food-and-drink">
   <h2 class="food-and-drink__heading">{{title}}</h2>
 
 

--- a/src/components/guidebook/guidebook.hbs
+++ b/src/components/guidebook/guidebook.hbs
@@ -1,5 +1,5 @@
 {{#if books }}
-  <article class="guidebook" id="guidebook">
+  <article class="guidebook">
     <header class="guidebook__header">
       <h2 class="guidebook__title">{{ title }}</h2>
       {{#if subtitle }}
@@ -32,7 +32,7 @@
                   {{small.lossless}} 3x">
       </picture>
       {{/with}}
-  
+
       {{#if second_image}}
       {{#with second_image}}
       <picture class="guidebook__picture guidebook__picture--secondary">

--- a/src/components/interests/interests.hbs
+++ b/src/components/interests/interests.hbs
@@ -1,5 +1,5 @@
 {{#if card_count}}
-  <article id="interests" class="interests">
+  <article class="interests">
     <h2 class="interests__heading">{{ interests.title }}</h2>
 
     <section class="interests__cards interests__cards--{{ card_count }}">

--- a/src/components/intro_narrative/intro_narrative.hbs
+++ b/src/components/intro_narrative/intro_narrative.hbs
@@ -1,4 +1,4 @@
-<article id="introduction" class="intro-narrative">
+<article class="intro-narrative">
   <h2 class="intro-narrative__heading">{{{intro_narrative_title}}}</h2>
 
   <p class="intro-narrative__text">

--- a/src/components/love_letter/love_letter.hbs
+++ b/src/components/love_letter/love_letter.hbs
@@ -1,4 +1,4 @@
-<article id="introduction" class="love-letter">
+<article class="love-letter">
   <h2 class="love-letter__heading">{{{love_letter_title}}}</h2>
 
   <p class="love-letter__text">

--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,4 +1,4 @@
-<article id="maps" class="map_static">
+<article class="map_static">
   <div class="map_static__container" data-preload="{{static_map.map_url}}" style="background-image: url('{{static_map.map_url}}')">
     {{!-- hide button until ready for preview --}}
     <button class="map_static__btn js-open-map">

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -3,13 +3,28 @@ require("./_sub_nav.scss");
 export default class SubNav {
   constructor() {
     let debounce = require("lodash/function/debounce"),
-        $subNav = $(".js-sub-nav");
+        $subNav = $(".js-sub-nav"),
+        $window = $(window);
+
+    /**
+     * Checks to see if a given element has been scrolled into view
+     * @param  {Object}  element Element to check
+     * @return {Boolean}         Is the element in view or not?
+     */
+    let isScrolledIntoView = (element) => {
+      let $element = $(element),
+          windowTop = $window.scrollTop(),
+          elementTop = $element.offset().top,
+          viewportTop = windowTop + ($subNav.height() * 2);
+
+      return elementTop <= viewportTop;
+    };
 
     if ($subNav.length) {
       let subNavTop = $subNav.offset().top,
           firstTrigger = true,
-          $window = $(window),
-          fixedState, fixedSubNav;
+          fixedState,
+          fixedSubNav;
 
       $(document).on("click", ".js-sub-nav-link", function(e) {
         let target = this.hash;
@@ -48,20 +63,18 @@ export default class SubNav {
           firstTrigger = false;
         }
 
-        if ($window.scrollTop() > subNavTop){
-          if(!fixedState){
-            fixedSubNav.appendTo( "body" );
+        if ($window.scrollTop() > subNavTop) {
+          if(!fixedState) {
+            fixedSubNav.appendTo("body");
             fixedState = true;
           }
         } else if (fixedState) {
-            fixedSubNav.detach();
-            fixedState = false;
+          fixedSubNav.detach();
+          fixedState = false;
         }
 
-        let scrollTop = $(window).scrollTop() + $subNav.height();
-
         let $current = $components.map((i, el) => {
-          if (el.offsetTop < scrollTop) {
+          if (isScrolledIntoView(el)) {
             return el;
           }
         });
@@ -72,6 +85,10 @@ export default class SubNav {
           fixedSubNav
             .find(`a[href*="#${$current[$current.length - 1].id}"]`)
               .addClass("sub-nav__link--active");
+
+        } else {
+          fixedSubNav.find("a").removeClass("sub-nav__link--active");
+
         }
 
       }, 10));

--- a/src/components/survival_guide/survival_guide.hbs
+++ b/src/components/survival_guide/survival_guide.hbs
@@ -1,6 +1,6 @@
 {{#if survival_guide.items}}
 
-<div class="survival-guide" id="survival-guide">
+<div class="survival-guide">
   <h2 class="survival-guide__heading">{{survival_guide.title}}</h2>
 
   <ul class="survival-guide__list">

--- a/src/components/things_to_do/things_to_do.hbs
+++ b/src/components/things_to_do/things_to_do.hbs
@@ -1,6 +1,6 @@
 {{#with top_things_to_do}}
 {{#if cards}}
-<article id="ttd" class="ttd" data-lp-initial-cards="{{cards}}">
+<article class="ttd" data-lp-initial-cards="{{cards}}">
   <h2 class="ttd__heading">{{title}}</h2>
 
   <ul class="ttd__list">

--- a/src/components/tours/tours.hbs
+++ b/src/components/tours/tours.hbs
@@ -1,5 +1,5 @@
 {{#if tours}}
-  <article id="tours" class="tours">
+  <article class="tours">
     <h2 class="tours__heading">{{title}}</h2>
 
     <div class="tours__list">


### PR DESCRIPTION
Part of the problem was that the `id` attribute was placed on a nested `div`. For better accuracy, IDs that were once placed at the component level in Rizzo have been moved to the outermost `div` in DN templates. Since the outermost `div` has top and bottom padding, this is where the height and offset needs to be calculated. Otherwise, any calculations made on nested `div`s will produce inaccurate results.

Related: https://github.com/lonelyplanet/destinations-next/pull/389