### PR TITLE
Maps: Add sidebar header when fetching new place

### DIFF
--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -28,7 +28,6 @@ let MapActions = {
       url: url
     }).done((results) => {
       // window.localStorage.setItem(url, JSON.stringify(results));
-      console.log(results);
       Arkham.trigger("place.fetched", results);
     }).error((results) => {
       let error = {

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -11,11 +11,11 @@ let MapActions = {
     Arkham.trigger("view.changed", data);
   },
 
-  gotoPlace: ({ placeTitle, place, topic="" }) => {
+  gotoPlace: ({ placeTitle, place, breadcrumb, topic="" }) => {
     let query = topic ? `?topic=${topic.toLowerCase()}` : "",
         url = `/${place}/map.json${query}`;
 
-    Arkham.trigger("place.fetching", { placeTitle });
+    Arkham.trigger("place.fetching", { placeTitle, breadcrumb });
 
     // TODO: JC, maybe this is cool, maybe not?
     // let mapData = window.localStorage.getItem(url);

--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -15,7 +15,7 @@ let MapActions = {
     let query = topic ? `?topic=${topic.toLowerCase()}` : "",
         url = `/${place}/map.json${query}`;
 
-    Arkham.trigger("place.fetching", { placeTitle, breadcrumb });
+    Arkham.trigger("place.fetching", { placeTitle, breadcrumb, topic });
 
     // TODO: JC, maybe this is cool, maybe not?
     // let mapData = window.localStorage.getItem(url);

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -159,7 +159,7 @@ class MarkerSet extends Component {
     let poiIndex = this.activeLayer.feature.properties.index,
         poi = this.pois[poiIndex];
     if (poi.item_type === "Place") {
-      MapActions.gotoPlace({ place: poi.slug, placeTitle: poi.title });
+      MapActions.gotoPlace({ place: poi.slug, placeTitle: poi.title, breadcrumb: poi.subtitle });
     } else {
       MapActions.poiOpen({ index: poiIndex, poi });
     }

--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -8,11 +8,6 @@ $unit: $size / 16;
   100% { transform: rotate(360deg); }
 }
 
-.fetching {
-  text-align: center;
-  padding: $gutter;
-}
-
 .spinner {
   display: block;
   width: $size;

--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -2,6 +2,7 @@ $inactive: #999;
 $active: $lpblue;
 $size: 3rem;
 $unit: $size / 16;
+$panel-height: calc(100% - #{$sidebar-header-height});
 
 @keyframes spinner {
   0% { transform: rotate(0); }
@@ -16,7 +17,8 @@ $unit: $size / 16;
   border: $unit solid $inactive;
   animation: spinner $animation-speed-ui linear infinite;
   position: relative;
-  margin: 2rem auto;
+  top: calc(50% - (#{$size} / 2);
+  margin: 0 auto;
 
   &:before,
   &:after {
@@ -216,7 +218,7 @@ $unit: $size / 16;
   }
 
   .panel {
-    height: calc(100% - #{$sidebar-header-height});
+    height: $panel-height;
     overflow: auto;
 
     .listing {

--- a/src/components/map/state.js
+++ b/src/components/map/state.js
@@ -25,7 +25,8 @@ let state = {
   hoveredItem: null,
   customPanel: "",
   tabDropdownOpen: false,
-  placeParent: ""
+  placeParent: "",
+  topicClicked: ""
 };
 
 let MapState = assign({
@@ -96,6 +97,7 @@ Arkham.on("place.fetching", (data) => {
   state.isFetching = true;
   state.fetchingPlace = data.placeTitle;
   state.placeParent = data.breadcrumb;
+  state.topicClicked = data.topic;
   MapState.emitChange();
 });
 

--- a/src/components/map/state.js
+++ b/src/components/map/state.js
@@ -24,7 +24,8 @@ let state = {
   hoveredPin: 0,
   hoveredItem: null,
   customPanel: "",
-  tabDropdownOpen: false
+  tabDropdownOpen: false,
+  placeParent: ""
 };
 
 let MapState = assign({
@@ -94,6 +95,7 @@ Arkham.on("poi.closed", () => {
 Arkham.on("place.fetching", (data) => {
   state.isFetching = true;
   state.fetchingPlace = data.placeTitle;
+  state.placeParent = data.breadcrumb;
   MapState.emitChange();
 });
 

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -59,7 +59,7 @@ export default class ItemView extends React.Component {
   clickItem() {
     let props = this.props;
     if(props.item.item_type === "Place") {
-      MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title });
+      MapActions.gotoPlace({ place: props.item.slug, placeTitle: props.item.title, breadcrumb: props.item.subtitle });
     } else {
       MapActions.poiOpen({ index: props.item.i, poi: props.item });
       MapActions.pinHover({ poiIndex: props.item.i });

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -42,7 +42,7 @@ export default class MainView extends React.Component {
     }
 
     if (this.state.isFetching) {
-      sidebar = <SidebarFetching poi={this.state.poi} place={this.state.fetchingPlace} />;
+      sidebar = <SidebarFetching location={this.state.currentLocation} sets={this.state.sets} poi={this.state.poi} place={this.state.fetchingPlace} />;
     } else {
       if (this.state.isDetail) {
         sidebar = <SidebarDetails poi={this.state.poi} />

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -42,7 +42,7 @@ export default class MainView extends React.Component {
     }
 
     if (this.state.isFetching) {
-      sidebar = <SidebarFetching location={this.state.currentLocation} sets={this.state.sets} poi={this.state.poi} place={this.state.fetchingPlace} />;
+      sidebar = <SidebarFetching location={this.state.currentLocation} place={this.state.fetchingPlace} breadcrumb={this.state.placeParent} />;
     } else {
       if (this.state.isDetail) {
         sidebar = <SidebarDetails poi={this.state.poi} />

--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -42,7 +42,7 @@ export default class MainView extends React.Component {
     }
 
     if (this.state.isFetching) {
-      sidebar = <SidebarFetching place={this.state.fetchingPlace} />;
+      sidebar = <SidebarFetching poi={this.state.poi} place={this.state.fetchingPlace} />;
     } else {
       if (this.state.isDetail) {
         sidebar = <SidebarDetails poi={this.state.poi} />

--- a/src/components/map/views/sidebar-dropdown.jsx
+++ b/src/components/map/views/sidebar-dropdown.jsx
@@ -24,20 +24,25 @@ export default class SidebarDropdown extends React.Component {
   }
   render() {
     let topicCount = 0,
-        classString = "tab__sub-nav";
+        menuClassString = "tab__sub-nav";
 
     let topics = this.state.topics.map((item) => {
+      let itemClassString = "tab__sub-nav__list--item";
+      if (this.state.topicClicked === item) {
+        itemClassString += " is-selected";
+      }
+
       return (
-        <li className="tab__sub-nav__list--item" data-item={item} onClick={this.changeTopic.bind(this)}>{item}</li>
+        <li className={itemClassString} data-item={item} onClick={this.changeTopic.bind(this)}>{item}</li>
       );
     });
 
     if (this.props.tabDropdownOpen) {
-      classString += " is-visible";
+      menuClassString += " is-visible";
     }
 
     return (
-      <div className={classString}>
+      <div className={menuClassString}>
         <ul className="tab__sub-nav__list">
           {topics}
         </ul>

--- a/src/components/map/views/sidebar-dropdown.jsx
+++ b/src/components/map/views/sidebar-dropdown.jsx
@@ -18,7 +18,8 @@ export default class SidebarDropdown extends React.Component {
 
     MapActions.gotoPlace({
       place: this.state.currentLocation.slug,
-      topic
+      topic,
+      breadcrumb: this.state.currentLocation.parent
     });
   }
   render() {

--- a/src/components/map/views/sidebar-fetching.jsx
+++ b/src/components/map/views/sidebar-fetching.jsx
@@ -6,10 +6,17 @@ import React from "react";
 export default class SidebarFetchingView extends React.Component {
 
   render() {
+    let poi = this.props.poi;
+
     return (
       <div className="sidebar fetching">
-        <span>Fetching {this.props.place}</span>
-        <br/>
+        <header className="sidebar__header">
+          <div className="location-subtitle" ></div>
+          <h1 className="sidebar__title">
+            {this.props.place}
+          </h1>
+          <div className="sidebar__tabs"></div>
+        </header>
         <div className='spinner'></div>
       </div>
     )

--- a/src/components/map/views/sidebar-fetching.jsx
+++ b/src/components/map/views/sidebar-fetching.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Tab from "./tab.jsx";
 
 /**
  * Shows when items are being fetched
@@ -6,16 +7,42 @@ import React from "react";
 export default class SidebarFetchingView extends React.Component {
 
   render() {
-    let poi = this.props.poi;
+    let poi = this.props.poi,
+        location = this.props.location,
+        sets = this.props.sets,
+        backElement = "",
+        tabCount = 0;
+
+    let tabs = sets.map((set, i) => {
+      tabCount++;
+      return (
+        <Tab sets={sets} name={set.title} i={i} type={set.type} />
+      )
+    });
+
+    if (location.description.length > 0) {
+      tabCount++;
+      let aboutTab = <Tab name="About" i={tabCount} customPanel="about" />
+      tabs.push(aboutTab);
+    }
+
+    console.log(location);
+    if (location.grandparent) {
+      backElement = <div className="location-subtitle" ><i className="icon icon-chevron-left" aria-hidden="true"></i>{location.grandparent}</div>;
+    }
 
     return (
       <div className="sidebar fetching">
         <header className="sidebar__header">
-          <div className="location-subtitle" ></div>
+          <div className="location-subtitle" >
+            {backElement}
+          </div>
           <h1 className="sidebar__title">
             {this.props.place}
           </h1>
-          <div className="sidebar__tabs"></div>
+          <div className="sidebar__tabs">
+
+          </div>
         </header>
         <div className='spinner'></div>
       </div>

--- a/src/components/map/views/sidebar-fetching.jsx
+++ b/src/components/map/views/sidebar-fetching.jsx
@@ -7,29 +7,12 @@ import Tab from "./tab.jsx";
 export default class SidebarFetchingView extends React.Component {
 
   render() {
-    let poi = this.props.poi,
-        location = this.props.location,
-        sets = this.props.sets,
-        backElement = "",
-        tabCount = 0;
+    let location = this.props.location,
+        breadcrumb = this.props.breadcrumb,
+        crumbText =  breadcrumb || location.grandparent,
+        placeText = this.props.place || location.title;
 
-    let tabs = sets.map((set, i) => {
-      tabCount++;
-      return (
-        <Tab sets={sets} name={set.title} i={i} type={set.type} />
-      )
-    });
-
-    if (location.description.length > 0) {
-      tabCount++;
-      let aboutTab = <Tab name="About" i={tabCount} customPanel="about" />
-      tabs.push(aboutTab);
-    }
-
-    console.log(location);
-    if (location.grandparent) {
-      backElement = <div className="location-subtitle" ><i className="icon icon-chevron-left" aria-hidden="true"></i>{location.grandparent}</div>;
-    }
+    let backElement = crumbText ? <div className="location-subtitle" ><i className="icon icon-chevron-left" aria-hidden="true"></i>{crumbText}</div> : ""
 
     return (
       <div className="sidebar fetching">
@@ -38,13 +21,13 @@ export default class SidebarFetchingView extends React.Component {
             {backElement}
           </div>
           <h1 className="sidebar__title">
-            {this.props.place}
+            {placeText}
           </h1>
-          <div className="sidebar__tabs">
-
-          </div>
+          <div className="sidebar__tabs"></div>
         </header>
-        <div className='spinner'></div>
+        <div className="panel">
+          <div className='spinner'></div>
+        </div>
       </div>
     )
   }

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -27,6 +27,7 @@ export default class SidebarView extends React.Component {
       let isCity = location.type.toLowerCase() === "city";
       let isExperienceTab = set.type === "experiences";
       let showDropdown = isCity && isExperienceTab;
+
       return (
         <Tab sets={sets} showDropdown={showDropdown} name={set.title} active={isActive} i={i} type={set.type} />
       )
@@ -35,7 +36,7 @@ export default class SidebarView extends React.Component {
     if (location.description.length > 0) {
       tabCount++;
       let dropdownOpen = this.props.tabDropdownOpen
-      let isActive = tabCount === activeSetIndex ? true : false;
+      let isActive = tabCount === 1 || tabCount === activeSetIndex ? true : false;
       let aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" tabDropdownOpen={dropdownOpen}/>
       tabs.push(aboutTab);
     }


### PR DESCRIPTION
Currently, when switching between views in the interactive map, the sidebar goes completely white, other than a loading animation. This PR adds the blue header during the fetching phase to make the visual transition between sidebar views less jarring.

Before:
![screen shot 2015-09-30 at 5 23 10 pm](https://cloud.githubusercontent.com/assets/3247835/10208287/f465d17a-6797-11e5-9f8c-df4ad0b759d2.png)

After:
![screen shot 2015-09-30 at 5 24 02 pm](https://cloud.githubusercontent.com/assets/3247835/10208320/254f4a0a-6798-11e5-8c2e-ed5adbacc06f.png)

Also piggy-backed on completed styling for the city experience tab dropdown, adding the class for blue highlighting and a bullet to the current topic.
![screen shot 2015-09-30 at 5 26 30 pm](https://cloud.githubusercontent.com/assets/3247835/10208354/6b9cc546-6798-11e5-8f63-4c8ee4774f88.png)
