### PR TITLE
Removing outline from guidebook pictures

### DIFF
--- a/src/components/guidebook/_guidebook.scss
+++ b/src/components/guidebook/_guidebook.scss
@@ -103,6 +103,7 @@
   width: 80%;
   margin: 2rem auto;
   text-align: center;
+  outline: 0;
 
   @media (min-width: $min-720) {
     margin: 5rem auto;


### PR DESCRIPTION
The markup has a `tabindex` of `-1` so the photos cannot be tabbed to because we want the button to have the focus, therefore removing the outline is ok in this case.