### PR TITLE
Wrap map close btn in clickable div

### DIFF
--- a/src/components/map/views/main.jsx
+++ b/src/components/map/views/main.jsx
@@ -55,7 +55,9 @@ export default class MainView extends React.Component {
 
     return (
       <div className={classString}>
-        <div className="close-map icon-close-small" onClick={this.closeMap}>Close</div>
+        <div id="close-map--wrapper" onClick={this.closeMap}>
+          <div className="close-map icon-close-small">Close</div>
+        </div>
         <Map pins={activeSet} location={this.state.currentLocation} index={this.state.activeIndex} />
         {sidebar}
         <Alert error={this.state.error} />


### PR DESCRIPTION
This moves the 'close map' click event to a wrapper around the btn so the map closes when user clicks anywhere above or below the btn.