### PR TITLE
Make map sidebar render tab for other topics when no experiences

### DIFF
--- a/src/components/map/views/sidebar-dropdown.jsx
+++ b/src/components/map/views/sidebar-dropdown.jsx
@@ -13,8 +13,14 @@ export default class SidebarDropdown extends React.Component {
     this.state = MapState.getState();
   }
 
+  componentDidMount() {
+    if( !$(".is-selected").length )
+      $(".tab__sub-nav__list--item:first-child").addClass("is-selected");
+  }
+
   changeTopic(event) {
     let topic = $(event.currentTarget).data("item");
+    $(".tab__sub-nav__list--item").removeClass("is-selected");
 
     MapActions.gotoPlace({
       place: this.state.currentLocation.slug,
@@ -22,9 +28,9 @@ export default class SidebarDropdown extends React.Component {
       breadcrumb: this.state.currentLocation.parent
     });
   }
+
   render() {
-    let topicCount = 0,
-        menuClassString = "tab__sub-nav";
+    let menuClassString = "tab__sub-nav";
 
     let topics = this.state.topics.map((item) => {
       let itemClassString = "tab__sub-nav__list--item";

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -20,13 +20,11 @@ export default class SidebarView extends React.Component {
         backElement = "",
         h1Class = "sidebar__title __continent";
 
-
     let tabs = sets.map((set, i) => {
       tabCount++;
-      let isActive = i === activeSetIndex ? true : false;
-      let isCity = location.type.toLowerCase() === "city";
-      let isExperienceTab = set.type === "experiences";
-      let showDropdown = isCity && isExperienceTab;
+      let isActive = i === activeSetIndex ? true : false,
+          isCity = location.type.toLowerCase() === "city",
+          showDropdown = isCity && tabCount === 1;
 
       return (
         <Tab sets={sets} showDropdown={showDropdown} name={set.title} active={isActive} i={i} type={set.type} />
@@ -35,9 +33,9 @@ export default class SidebarView extends React.Component {
 
     if (location.description.length > 0) {
       tabCount++;
-      let dropdownOpen = this.props.tabDropdownOpen
-      let isActive = tabCount === 1 || tabCount === activeSetIndex ? true : false;
-      let aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" tabDropdownOpen={dropdownOpen}/>
+      let dropdownOpen = this.props.tabDropdownOpen,
+          isActive = tabCount === 1 || tabCount === activeSetIndex ? true : false,
+          aboutTab = <Tab name="About" active={isActive} i={tabCount} customPanel="about" tabDropdownOpen={dropdownOpen}/>
       tabs.push(aboutTab);
     }
 

--- a/src/components/map/views/tab.jsx
+++ b/src/components/map/views/tab.jsx
@@ -24,7 +24,7 @@ export default class TabView extends React.Component {
 
     if (this.props.showDropdown) {
       classString += " experiences"
-      sidebarDropdown = <SidebarDropdown sets={sets} tabDropdownOpen={this.state.openDropdown}/>
+      sidebarDropdown = <SidebarDropdown tabDropdownOpen={this.state.openDropdown}/>
       iconAfter = "tab__icon icon--chevron-down icon--white";
     }
 
@@ -47,13 +47,11 @@ export default class TabView extends React.Component {
   }
 
   showSubmenu() {
-    if (this.props.type === "experiences") {
-      clearTimeout(this.hideTimer);
+    clearTimeout(this.hideTimer);
 
-      this.showTimer = setTimeout(() => {
-        this.setState({ openDropdown: true });
-      }, 0);
-    }
+    this.showTimer = setTimeout(() => {
+      this.setState({ openDropdown: true });
+    }, 0);
   }
 
   hideSubmenu() {

--- a/src/components/map_static/map_static.hbs
+++ b/src/components/map_static/map_static.hbs
@@ -1,6 +1,5 @@
 <article class="map_static">
   <div class="map_static__container" data-preload="{{static_map.map_url}}" style="background-image: url('{{static_map.map_url}}')">
-    {{!-- hide button until ready for preview --}}
     <button class="map_static__btn js-open-map">
       <i class="icon--open"></i>
       <span class="map_static__btn__text">launch map view</span>


### PR DESCRIPTION

Previously, when a place had no experiences, no tab was rendered in the map sidebar, which also meant no dropdown menu would render even if other things to do were present. A tab will now always be created as long as a topic with POIs exists.
Also adds highlighted styling for the first item in the drop down when it first renders.

![screen shot 2015-10-09 at 4 34 32 pm](https://cloud.githubusercontent.com/assets/3247835/10406437/83f37400-6ea5-11e5-93e4-31f46cae2ac9.png)

