### PR TITLE
Adding `transform: scale(1)` to F&D anchor

### DIFF
--- a/src/components/food_and_drink/_food_and_drink.scss
+++ b/src/components/food_and_drink/_food_and_drink.scss
@@ -90,7 +90,8 @@ $item-border-color: #f1f4fb;
 
      transition: transform $animation-speed;
 
-     backface-visibility: hidden;
+     backface-visibility: hidden; // Fix hidden content bug in Chrome, FF, Opera
+     transform: scale(1); // Fix hidden content bug in Safari
     }
 
     &:hover a {


### PR DESCRIPTION
In addtion to `backface-visibilty: hidden`, `transform: scale(1)` has been added to fix a bug across Chrome, Safari and Firefox.

Initially, `backface-visibility` was added because of a bug in Chrome, FF and Opera. When an item in the right column was hovered, the content would disappear. Interestingly, `backface-visibility` had the complete opposite effect in Safari; all of the content was hidden. Adding `transform: scale(1)` fixes Safari and has no effect on other browsers.

The issue stems from the use of CSS3 columns. It seems there is a bug when a transition is used inside of a column item.