### PR TITLE
Improve sub-nav performance

### DIFF
--- a/src/components/sub_nav/_sub_nav.scss
+++ b/src/components/sub_nav/_sub_nav.scss
@@ -17,14 +17,36 @@ $navigation-sub-height-mobile: $header-height-mobile;
   }
 }
 
+.sub-nav-placeholder {
+  display: block;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  visibility: hidden;
+  z-index: -1;
+
+  &.is-fixed {
+    height: $navigation-sub-height-mobile + .1;
+
+    @media (min-width: $min-720) {
+      height: $navigation-sub-height + .1;
+    }
+  }
+}
+
 .sub-nav {
   position: relative;
   margin: 0;
   padding: 0;
   font-size: 0;
   background-color: #fff;
+  height: $navigation-sub-height-mobile + .1;
 
-  &--fixed {
+  @media (min-width: $min-720) {
+    height: $navigation-sub-height + .1;
+  }
+
+  &.is-fixed {
     @include z-layer(top);
     position: fixed;
     top: 0;
@@ -51,7 +73,6 @@ $navigation-sub-height-mobile: $header-height-mobile;
   }
 
   &__container {
-    height: $navigation-sub-height-mobile;
     margin: 0;
     overflow: hidden;
 
@@ -74,15 +95,11 @@ $navigation-sub-height-mobile: $header-height-mobile;
       right: 0;
       background: linear-gradient(to left, rgba(#fff, 1) 0%, rgba(#fff, 0) 100%);
     }
-
-    @media (min-width: $min-720) {
-      height: $navigation-sub-height;
-    }
   }
 
   &__list {
     width: 100%;
-    height: $navigation-sub-height-mobile + 2rem;
+    height: $navigation-sub-height-mobile;
     margin: 0;
     padding: 0;
     overflow-x: auto;
@@ -98,7 +115,7 @@ $navigation-sub-height-mobile: $header-height-mobile;
     }
 
     @media (min-width: $min-720) {
-      height: $navigation-sub-height + 2rem;
+      height: $navigation-sub-height;
     }
   }
 

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -1,10 +1,11 @@
 import { Component } from "../../core/bane";
+import debounce from "lodash/function/debounce";
 require("./_sub_nav.scss");
 
 export default class SubNav extends Component {
   initialize() {
-    let debounce = require("lodash/function/debounce"),
-        $subNav = $(".js-sub-nav"),
+    let $subNav = $(".js-sub-nav"),
+        $subNavPlaceholder = $(".js-sub-nav-placeholder"),
         $window = $(window);
 
     /**
@@ -24,8 +25,7 @@ export default class SubNav extends Component {
     if ($subNav.length) {
       let subNavTop = $subNav.offset().top,
           firstTrigger = true,
-          fixedState,
-          fixedSubNav;
+          fixedState;
 
       $(document).on("click", ".js-sub-nav-link", function(e) {
         let target = this.hash;
@@ -57,21 +57,21 @@ export default class SubNav extends Component {
 
       $window.scroll(debounce(() => {
         if (firstTrigger) {
-          fixedSubNav = $subNav
-            .clone(true)
-            .addClass("sub-nav--fixed");
-
           firstTrigger = false;
         }
 
-        if ($window.scrollTop() > subNavTop) {
+        if ($window.scrollTop() >= subNavTop) {
           if(!fixedState) {
-            fixedSubNav.appendTo("body");
+            $subNav.addClass("is-fixed");
             fixedState = true;
+
+            $subNavPlaceholder.addClass("is-fixed");
           }
         } else if (fixedState) {
-          fixedSubNav.detach();
+          $subNav.removeClass("is-fixed");
           fixedState = false;
+
+          $subNavPlaceholder.removeClass("is-fixed");
         }
 
         let $current = $components.map((i, el) => {
@@ -81,14 +81,14 @@ export default class SubNav extends Component {
         });
 
         if ($current.length) {
-          fixedSubNav.find("a").removeClass("sub-nav__link--active");
+          $subNav.find("a").removeClass("sub-nav__link--active");
 
-          fixedSubNav
+          $subNav
             .find(`a[href*="#${$current[$current.length - 1].id}"]`)
               .addClass("sub-nav__link--active");
 
         } else {
-          fixedSubNav.find("a").removeClass("sub-nav__link--active");
+          $subNav.find("a").removeClass("sub-nav__link--active");
 
         }
 

--- a/src/components/sub_nav/sub_nav.hbs
+++ b/src/components/sub_nav/sub_nav.hbs
@@ -1,3 +1,4 @@
+<div class="sub-nav-placeholder js-sub-nav-placeholder"></div>
 <nav id="sub-nav" class="sub-nav js-sub-nav">
   <div class="sub-nav__wrap">
     <div class="sub-nav__container">


### PR DESCRIPTION
The sub-nav was being cloned and then re-appended to the DOM; I suspected this to be less performant than just adding a class to the already existing sub-nav. I created a [jsperf test](http://jsperf.com/sticky-navigation-clone-and-append-vs-adding-class) to confirm.

My hope is that this update will allow the sub-nav to perform better on mobile.