### PR TITLE
Fix read more link wrap in intro

### DIFF
--- a/src/components/intro_narrative/_intro_narrative.scss
+++ b/src/components/intro_narrative/_intro_narrative.scss
@@ -62,8 +62,7 @@ $small-breakpoint: 320;
 
   &__more {
     @include more();
-
-    text-transform: uppercase;
+    display: inline-block;
     font-style: normal;
   }
 }

--- a/src/components/love_letter/_love_letter.scss
+++ b/src/components/love_letter/_love_letter.scss
@@ -55,9 +55,7 @@ $small-breakpoint: 320;
 
   &__more {
     @include more();
-
-    text-transform: uppercase;
-    font-family: $font-family;
+    display: inline-block;
     font-style: normal;
   }
 }


### PR DESCRIPTION
Adding `display: inline-block` seems to keep the text and icon together and prevents it from breaking to two lines. Applied to both intro narrative and love letter. Removed `text-transform: uppercase` as it's already being applied within the `more` mixin. Also, no need to redefine `font-family` in `love-letter__more`, so that property has been removed.