### PR TITLE
Make map item images background-image

### DIFF
--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -85,6 +85,7 @@
 
   &__pic {
     background-size: cover;
+    background-repeat: no-repeat;
     height: 100%;
     width: $image-width;
     overflow: hidden;

--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -84,20 +84,13 @@
   }
 
   &__pic {
+    background-size: cover;
     height: 100%;
     width: $image-width;
     overflow: hidden;
     position: absolute;
     top: 0;
     left: 0;
-
-    img {
-      position: absolute;
-      max-width: ($item-width-list * .6);
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-    }
   }
 
   &__order {

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -29,7 +29,7 @@ export default class ItemView extends React.Component {
       }
     }
     if (item.geo.properties.image) {
-      let imgSrc = "http://images-resrc.staticlp.com/S=W80/" + item.geo.properties.image;
+      let imgSrc = "http://images-resrc.staticlp.com/O=60/S=W80/" + item.geo.properties.image;
       imgStyle = { backgroundImage: `url(${imgSrc})` };
     }
     else {

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -12,6 +12,7 @@ export default class ItemView extends React.Component {
     let classString = "place ";
     let img = "";
     let picClass = "place__pic";
+    let imgStyle;
 
     if (item.onMap) {
       classString += "pin icon icon--chevron-right";
@@ -28,8 +29,8 @@ export default class ItemView extends React.Component {
       }
     }
     if (item.geo.properties.image) {
-      let imgSrc = "http://images-resrc.staticlp.com/S=H150/" + item.geo.properties.image;
-      img = <img src={imgSrc} />
+      let imgSrc = "http://images-resrc.staticlp.com/S=W80/" + item.geo.properties.image;
+      imgStyle = { backgroundImage: `url(${imgSrc})` };
     }
     else {
       // TODO: This will have to change when topics are correct
@@ -45,8 +46,7 @@ export default class ItemView extends React.Component {
     return (
       <div className={classString} onMouseEnter={this.hoverItem.bind(this)} onClick={this.clickItem.bind(this)}>
         <div className="place__pointer"></div>
-        <div className={picClass}>
-          {img}
+        <div className={picClass} style={imgStyle}>
         </div>
         <div className="place__order">{item.i+1}</div>
         <div className="place__text">


### PR DESCRIPTION
When images were set as tags and positioned absolutely, some were off-center or had important parts cut off. Setting them as background images allows for a much higher percentage of imgs to be presented correctly.
Before:
![screen shot 2015-10-13 at 3 13 08 pm](https://cloud.githubusercontent.com/assets/3247835/10466998/019fbf16-71bd-11e5-803a-aaf41bcbf481.png)

After:
![screen shot 2015-10-13 at 3 13 16 pm](https://cloud.githubusercontent.com/assets/3247835/10467010/118765f0-71bd-11e5-834c-0233b2ee3ae3.png)


