### PR TITLE
Update food and drink layout

### DIFF
--- a/src/components/food_and_drink/_food_and_drink.scss
+++ b/src/components/food_and_drink/_food_and_drink.scss
@@ -28,6 +28,7 @@ $item-border-color: #f1f4fb;
       width: $fad-column-width;
       margin-top: auto;
       margin-bottom: auto;
+      z-index: -1;
     }
   }
 
@@ -40,30 +41,43 @@ $item-border-color: #f1f4fb;
   }
 
   &__list {
-    position: relative;
     margin-bottom: ($spacing * 4);
     list-style: none;
 
     @media (min-width: $min-960) {
       overflow: hidden;
-      column-count: 2;
-      column-gap: $gutter;
     }
   }
 
   &__item {
-    display: block;
-    break-inside: avoid-column;
     border-bottom: .1rem solid $item-border-color;
 
-    &:first-child,
-    &:nth-child(6) {
+    @media (min-width: $min-960) {
+      width: calc(50% - #{$gutter});
+      float: left;
+    }
+
+    &:first-child {
       border-top: .1rem solid $item-border-color;
     }
 
-    @media (max-width: $max-960) {
-      &:nth-last-child(-n+5) {
-        display: none;
+    &:nth-child(2) {
+      @media (min-width: $min-960) {
+        border-top: .1rem solid $item-border-color;
+      }
+    }
+
+    &:nth-child(even) {
+      @media (min-width: $min-960) {
+        margin-left: $gutter;
+      }
+    }
+
+    @for $i from 5 through 9 {
+      &[data-index="#{$i}"] {
+        @media (max-width: $max-960) {
+          display: none;
+        }
       }
     }
 
@@ -72,8 +86,6 @@ $item-border-color: #f1f4fb;
      padding-top: 2.1rem;
      padding-bottom: 1.8rem;
      transition: transform $animation-speed;
-     backface-visibility: hidden; // Fix hidden content bug in Chrome, FF, Opera
-     transform: scale(1); // Fix hidden content bug in Safari
     }
 
     &:hover a {

--- a/src/components/food_and_drink/food_and_drink.hbs
+++ b/src/components/food_and_drink/food_and_drink.hbs
@@ -11,7 +11,7 @@
   <div class="food-and-drink__inner">
     <ol class="food-and-drink__list">
       {{#each food_and_drink}}
-        <li class="food-and-drink__item">
+        <li class="food-and-drink__item" data-index="{{@index}}">
           <a href="http://www.lonelyplanet.com/{{url}}" itemscope itemtype="http://schema.org/FoodEstablishment">
 
             <div class="food-and-drink__title" itemprop="name">{{name}}</div>


### PR DESCRIPTION
Previously, the food and drink component used CSS columns for layout. There were a couple of issues:

1. No support for IE 9. While there has been discussion about dropping support for this browser, it has not been made official.
2. The current implementation assumed that there would always be 10 items. There were some fragile `nth-child` conditions in the code that broke the layout when there weren't 10 items. For example, /ireland/northern-ireland/ballycastle has 5 items and with the `nth-last-child(-n+5)` condition, no items would appear on screens less than 960px. This has been fixed by adding an index to the markup and then with a Sass loop, we can explicitly hide the last five items, regardless of the number of total items. Also, the `nth-child(6)` condition was being used to add a border, but it also breaks when there aren't 6 items.

The solution was to replace CSS columns with floats. This does change how the items are ordered (left to right instead of top to bottom), but this solution ensures compatibility with older browers and makes our `nth-child` condtions less fragile.

Changing the layout to floats also allowed for removal of a couple of hacks to fix a bug with transitioned elements inside of column. Those were the `backface-visibility` and `transform` properties on the anchor element.

Lastly, a `z-index` of -1 was added back to the image element just in case the image and the heading should ever overlap, the image will not cover up the heading.

<img width="562" alt="screen shot 2015-10-14 at 12 09 09 pm" src="https://cloud.githubusercontent.com/assets/1479563/10491488/82c93c5c-726c-11e5-940f-1b472601789c.png">

<img width="1548" alt="screen shot 2015-10-14 at 12 09 31 pm" src="https://cloud.githubusercontent.com/assets/1479563/10491509/9b42da0e-726c-11e5-825b-faed74e86683.png">