### PR TITLE
Drop flexbox from tours layout

### DIFF
--- a/src/components/tours/_tours.scss
+++ b/src/components/tours/_tours.scss
@@ -18,8 +18,6 @@ $tours-width: 52rem / $tours-width-base * 100%;
 
 .tours__list {
   @include clearfix;
-  display: flex;
-  flex-flow: row wrap;
   margin: 0 auto;
   width: $tours-container-width;
 
@@ -60,7 +58,6 @@ $tours-width: 52rem / $tours-width-base * 100%;
   }
 
   @media (min-width: $min-1290) {
-    float: none;
     width: $tours-width;
   }
 


### PR DESCRIPTION
To fix an earlier layout bug in the tours component Flexbox was added to make the items justify left when there was an uneven number of tour items. But we discovered that the layout broke in Safari, even though Flexbox is supported. Quickest fix was to drop flexbox and use good old fashioned floats.