### PR TITLE
Make notification badge reusable

### DIFF
--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -18,7 +18,8 @@ class NavigationComponent extends Component {
 
     this.notification = new Notification({
       target: this.$el.find(".js-cart-notification"),
-      content: this.state.cartItemCount
+      content: this.state.cartItemCount,
+      className: "notification-badge--shop"
     });
 
     this.name = "navigation";

--- a/src/components/navigation/user_panel.hbs
+++ b/src/components/navigation/user_panel.hbs
@@ -1,6 +1,6 @@
 <a class="avatar" href="//www.lonelyplanet.com/thorntree/profiles/{{user.profileSlug}}{{#if user.notification_count}}/messages{{/if}}">
   {{#if user.notification_count}}
-    <span class="notification-badge">{{user.notification_count}}</span>
+    <span class="notification-badge notification-badge--user">{{user.notification_count}}</span>
   {{/if}}
 
   <img src="{{user.avatar}}" alt="{{user.username}} avatar">

--- a/src/components/notification/_notification.scss
+++ b/src/components/notification/_notification.scss
@@ -1,37 +1,30 @@
 @import "../../../sass/webpack_deps";
 
+$notification-badge-size: 1.7rem;
 
-
-$wide-breakpoint: 1000px;
-
-.notification-badge{
-  $size: 1.7rem;
-
-  position: absolute;
-
-  top: $header-height / 2 - $size / 2;
-  right: 0;
-
-  margin: 0;
-
-  width: $size;
-  height: $size;
-
-  font-family: "freight","Helvetica Neue",Arial,Helvetica,sans-serif;
-  //font-size: 10px;
-  //font-size: .71429rem;
+.notification-badge {
+  width: $notification-badge-size;
+  height: $notification-badge-size;
   font-size: 1rem;
   font-weight: bold;
   font-style: normal;
-  line-height: $size - .1rem;
+  line-height: ($notification-badge-size + .1);
   text-align: center;
   color: #fff;
-
   border-radius: 50%;
   background-color: $color-red;
   box-shadow: 0 .1rem .2rem rgba(0,0,0, .2);
-
   user-select: none;
+}
 
-  transform: translate(.6rem, -1rem);
+.notification-badge--shop {
+  position: absolute;
+  top: ($header-height / 2) - ($notification-badge-size / 2) - 1;
+  right: -.6rem;
+}
+
+.notification-badge--user {
+  position: absolute;
+  top: -.3rem;
+  right: -.4rem;
 }

--- a/src/components/notification/notification.hbs
+++ b/src/components/notification/notification.hbs
@@ -1,6 +1,6 @@
 {{!-- notification Widget --}}
 {{#if number}}
-<span class="notification-badge js-notification-badge">
+<span class="notification-badge{{#if className}} {{ className }}{{/if}} js-notification-badge">
   {{ number }}
 </span>
 {{/if}}

--- a/src/components/notification/notification.js
+++ b/src/components/notification/notification.js
@@ -5,12 +5,14 @@ class Notification extends Component {
   initialize(options) {
     this.content = options.content;
     this.target = options.target;
+    this.className = options.className;
     this.template = require("./notification.hbs");
     this.render();
   }
   render() {
     let notification = this.build({
-      number: this.content
+      number: this.content,
+      className: this.className
     });
     this.target.append(notification);
     return this;


### PR DESCRIPTION
This update removes some context specific styles (i.e., positioning) from the component's base styles and moves them to a modifier. This allows the badge to be reused in different contexts and doesn't require overriding certain properties.