### PR TITLE
Unstick sub-nav when it hits the bottom of the content area

### DIFF
--- a/src/components/sub_nav/_sub_nav.scss
+++ b/src/components/sub_nav/_sub_nav.scss
@@ -42,6 +42,7 @@ $navigation-sub-height-mobile: $header-height-mobile;
   background-color: #fff;
   height: ($navigation-sub-height-mobile + .1);
   transform: translateZ(0); // force hardware acceleration for iOS
+  transition: opacity $animation-speed, visibility $animation-speed;
 
   @media (min-width: $min-720) {
     height: ($navigation-sub-height + .1);
@@ -53,6 +54,15 @@ $navigation-sub-height-mobile: $header-height-mobile;
     top: 0;
     left: 0;
     right: 0;
+  }
+
+  &.is-bottom {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    opacity: 0;
+    visibility: hidden;
   }
 
   &__wrap {

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -6,7 +6,12 @@ export default class SubNav extends Component {
   initialize() {
     let $subNav = $(".js-sub-nav"),
         $subNavPlaceholder = $(".js-sub-nav-placeholder"),
-        $window = $(window);
+        $window = $(window),
+        contentHeight = 0;
+
+    setTimeout(function() {
+      contentHeight = $(".navigation-wrapper").outerHeight();
+    }, 5000);
 
     /**
      * Checks to see if a given element has been scrolled into view
@@ -60,18 +65,32 @@ export default class SubNav extends Component {
           firstTrigger = false;
         }
 
-        if ($window.scrollTop() >= subNavTop) {
-          if(!fixedState) {
-            $subNav.addClass("is-fixed");
-            fixedState = true;
+        let isFixed = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() <= contentHeight),
+            isBottom = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() >= contentHeight);
 
-            $subNavPlaceholder.addClass("is-fixed");
-          }
-        } else if (fixedState) {
-          $subNav.removeClass("is-fixed");
-          fixedState = false;
+        if (isFixed) {
+          $subNav
+            .addClass("is-fixed")
+            .removeClass("is-bottom");
 
-          $subNavPlaceholder.removeClass("is-fixed");
+          $subNavPlaceholder
+            .addClass("is-fixed");
+
+        } else if (isBottom) {
+          $subNav
+            .addClass("is-bottom")
+            .removeClass("is-fixed");
+
+          $subNavPlaceholder
+            .addClass("is-fixed");
+
+        } else {
+          $subNav
+            .removeClass("is-fixed is-bottom");
+
+          $subNavPlaceholder
+            .removeClass("is-fixed");
+
         }
 
         let $current = $components.map((i, el) => {
@@ -95,7 +114,7 @@ export default class SubNav extends Component {
       }, 10));
 
       $window.resize(debounce(() => {
-        subNavTop = $subNav.offset().top;
+        contentHeight = $(".navigation-wrapper").outerHeight();
       }, 10));
     }
   }

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -1,4 +1,6 @@
 import { Component } from "../../core/bane";
+import RizzoEvents from "../../core/rizzo_events";
+import subscribe from "../../core/decorators/subscribe";
 import debounce from "lodash/function/debounce";
 require("./_sub_nav.scss");
 
@@ -6,12 +8,9 @@ export default class SubNav extends Component {
   initialize() {
     let $subNav = $(".js-sub-nav"),
         $subNavPlaceholder = $(".js-sub-nav-placeholder"),
-        $window = $(window),
-        contentHeight = 0;
+        $window = $(window);
 
-    setTimeout(function() {
-      contentHeight = $(".navigation-wrapper").outerHeight();
-    }, 5000);
+    this.contentHeight = 0;
 
     /**
      * Checks to see if a given element has been scrolled into view
@@ -65,8 +64,8 @@ export default class SubNav extends Component {
           firstTrigger = false;
         }
 
-        let isFixed = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() <= contentHeight),
-            isBottom = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() >= contentHeight);
+        let isFixed = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() <= this.contentHeight),
+            isBottom = ($window.scrollTop() >= subNavTop) && ($window.scrollTop() >= this.contentHeight);
 
         if (isFixed) {
           $subNav
@@ -114,8 +113,16 @@ export default class SubNav extends Component {
       }, 10));
 
       $window.resize(debounce(() => {
-        contentHeight = $(".navigation-wrapper").outerHeight();
+        this.updateContentHeight();
       }, 10));
     }
+
+    this.subscribe();
+  }
+
+  @subscribe(RizzoEvents.LOAD_BELOW, "events");
+
+  updateContentHeight() {
+    this.contentHeight = $(".navigation-wrapper").outerHeight();
   }
 }


### PR DESCRIPTION
This update "unsticks" the sub-nav when it hits the bottom of the content area and prevents it from covering the footer. The issue mostly occurs on mobile-sized screens.