### PR TITLE
Make char limit higher for sidebar items

### DIFF
--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -24,8 +24,8 @@ export default class ItemView extends React.Component {
       if (item.highlighted) {
         classString += " is-hovered";
       }
-      if (title.length > 30) {
-        title = title.substr(0, 29) + "...";
+      if (title.length > 36) {
+        title = title.substr(0, 35) + "...";
       }
     }
     if (item.geo.properties.image) {


### PR DESCRIPTION
Changing the map list items titles from the POI name to the stack name makes the titles longer in many cases. That, and recent design tweaks that left room for longer titles, led to this change. No big woop.