### PR TITLE
Hide sub nav when window is scrolled too fast on mobile

### DIFF
--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -7,6 +7,10 @@
   position: relative;
   z-index: 100;
 
+  &--narrow {
+    background-color: #fff;
+  }
+
   &--normal {
     position: absolute;
     z-index: 100;

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -12,6 +12,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
   max-height: 80rem;
   color: #fff;
   background-color: $h2-color;
+  z-index: 6;
 
   &--narrow {
     max-height: 70.8rem;


### PR DESCRIPTION
There's an issue on mobile devices when the window is scrolled too fast to the top, the sub nav doesn't have time to unstick itself in time and appears above the header and masthead. To "fix" this bug, I just added a z-index on the masthead one higher than the content area and added a white background to the header. This way, if the sub nav doesn't unstick in time, at least it's hidden.