### PR TITLE
Improve performance of fixed sub-nav on mobile when scrolling

### DIFF
--- a/src/components/sub_nav/_sub_nav.scss
+++ b/src/components/sub_nav/_sub_nav.scss
@@ -41,6 +41,7 @@ $navigation-sub-height-mobile: $header-height-mobile;
   font-size: 0;
   background-color: #fff;
   height: ($navigation-sub-height-mobile + .1);
+  transform: translateZ(0); // force hardware acceleration for iOS
 
   @media (min-width: $min-720) {
     height: ($navigation-sub-height + .1);
@@ -74,10 +75,10 @@ $navigation-sub-height-mobile: $header-height-mobile;
 
   &__container {
     overflow: hidden;
-    height: ($navigation-sub-height-mobile + .1);
+    height: $navigation-sub-height-mobile;
 
     @media (min-width: $min-720) {
-      height: ($navigation-sub-height + .1);
+      height: $navigation-sub-height;
     }
 
     &:before,


### PR DESCRIPTION
There's an issue on iOS Safari where the sub-nav is not visible and does not stick until the scroll is complete. To fix, hardware acceleration has been forced by adding `transform: translateZ(0);` to the sub-nav element.

Also, decreased the height of `sub-nav__container` so that the border does not sit below the white area of the sub-nav.