### PR TITLE
Remove notification badge styles from navigation item

### DIFF
--- a/src/components/navigation/_navigation.scss
+++ b/src/components/navigation/_navigation.scss
@@ -39,13 +39,6 @@
     }
   }
 
-  &__item--user {
-    .notification-badge {
-      right: .2rem;
-      top: .5rem;
-    }
-  }
-
   .navigation--narrow &__item--active {
     border-bottom-color: transparent;
   }


### PR DESCRIPTION
These styles are no longer needed because the notification badge component has a `user` modifier to position it within the user navigation.