### PR TITLE
Slightly refactor article allowing it work better in other contexts

### DIFF
--- a/src/components/articles/_articles.scss
+++ b/src/components/articles/_articles.scss
@@ -29,20 +29,17 @@ $small-breakpoint: 320;
 }
 
 .article {
-  @include divider;
   @include clearfix;
 
-  margin-bottom: 4.2rem;
-  padding-bottom: 4.8rem;
+  &:not(:first-child) {
+    @include divider(top);
+    margin-top: 4.8rem;
+    padding-top: 4.2rem;
 
-  @media (min-width: $min-1024) {
-    margin-bottom: 6.2rem;
-    padding-bottom: 6rem;
-  }
-
-  &:last-child {
-    margin-bottom: 0;
-    border-bottom: 0 none;
+    @media (min-width: $min-1024) {
+      margin-top: 6rem;
+      padding-top: 6.2rem;
+    }
   }
 }
 
@@ -175,6 +172,14 @@ $small-breakpoint: 320;
 
 .articles__button-container {
   text-align: center;
+
+  .articles__list + & {
+    margin-top: 4.8rem;
+
+    @media (min-width: $min-1024) {
+      margin-top: 6rem;
+    }
+  }
 }
 
 .articles__more {


### PR DESCRIPTION
- Uses the `:not` pseudo-class to apply styles directly and remove override
- Puts the margin, padding, border on the top instead of the bottom
- Adds top margin to button container when it's adjacent to article list