### PR TITLE
Add click event to map markers

### DIFF
--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -126,13 +126,14 @@ class MarkerSet extends Component {
       .on("mouseout", (e) => {
         this._poiUnhover(e.layer);
       });
+    
+    this.layer.off("click");
+    this.layer.on("click", (e) => {
+      this._poiClick(e);
+    });
   }
 
   _poiHover(layer) {
-    layer.off("click");
-    layer.addOneTimeEventListener('click', (e) => {
-        this._poiClick(e);
-      });
     // this._fixzIndex(layer); Not needed since pop-ups moved off the markers?
     let template = this._createIcon(layer);
     let lat = layer._latlng.lat;
@@ -159,7 +160,7 @@ class MarkerSet extends Component {
   }
 
   _poiClick(event) {
-    let poiIndex = this.activeLayer.feature.properties.index,
+    let poiIndex = (event.layer || this.activeLayer).feature.properties.index,
         poi = this.pois[poiIndex];
     if (poi.item_type === "Place") {
       MapActions.gotoPlace({ place: poi.slug, placeTitle: poi.title, breadcrumb: poi.subtitle });

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -13,8 +13,8 @@ class MarkerSet extends Component {
 
   initialize({ pois, map, layer }) {
     this.events = {
-      "click.marker .pin": "_poiClick",
-      "click.marker .poi": "_poiClick"
+      // "click.marker .poi": "_poiClick", doesn't work, because marker is z-indexed lower than popup-pane?
+      "click.marker .pin": "_poiClick"
     };
 
     this.pois = pois;
@@ -129,8 +129,11 @@ class MarkerSet extends Component {
   }
 
   _poiHover(layer) {
-    this._fixzIndex(layer);
-
+    layer.off("click");
+    layer.addOneTimeEventListener('click', (e) => {
+        this._poiClick(e);
+      });
+    // this._fixzIndex(layer); Not needed since pop-ups moved off the markers?
     let template = this._createIcon(layer);
     let lat = layer._latlng.lat;
     let lng = layer._latlng.lng;


### PR DESCRIPTION
Up to now, the user was unable to click on the map marker to load the "about" content in the map sidebar. You had to mouse up to the pop-up and click on that. This was a problem when markers were closely clustered because it was easy to accidentally hover over a different marker in the process. It also was a poor user experience to be able to hover, but not click, on the map marker. Thank you, @jcreamer898, for helping to get this working as it should