### PR TITLE
Navigation update after design review

### DIFF
--- a/src/components/navigation/_mobile-navigation.scss
+++ b/src/components/navigation/_mobile-navigation.scss
@@ -94,5 +94,19 @@
     &--active a {
       color: $color-primary;
     }
+
+    .icon {
+      float: right;
+      width: 1.3rem;
+      height: 1.3rem;
+      margin-top: .6rem;
+      transition: transform $animation-speed linear;
+    }
+
+    &.clicked {
+      .icon {
+        transform: rotateZ(180deg);
+      }
+    }
   }
 }

--- a/src/components/navigation/_sub-navigation.scss
+++ b/src/components/navigation/_sub-navigation.scss
@@ -21,8 +21,7 @@
     padding-bottom: 2.8rem;
 
     .mobile-sub-navigation & {
-      padding-top: 0;
-      padding-bottom: 1rem;
+      padding: 0
     }
   }
 
@@ -117,6 +116,10 @@
     height: auto;
     margin-right: 2.6rem;
     width: 8rem;
+
+    .mobile-sub-navigation & {
+      margin-right: 1rem;
+    }
   }
 
   &__text {

--- a/src/components/navigation/navigation.hbs
+++ b/src/components/navigation/navigation.hbs
@@ -35,7 +35,7 @@
       </li>
     {{/each}}
 
-    <li class="navigation__item navigation__item--user">
+    <li class="js-nav-item navigation__item navigation__item--user">
       {{! JavaScript will render the ./user_panel }}
     </li>
   </ul>
@@ -66,14 +66,14 @@
                 <a class="sub-navigation__link" href="/{{slug}}">{{title}}</a>
               </li>
             {{/each}}
-            </ul>
-
             {{#if submenu.call_to_action}}
-            <a class="sub-navigation__button" href="{{submenu.call_to_action.slug}}">
-              {{submenu.call_to_action.title}}
-              <i class="icon-chevron-right" aria-hidden="true"></i>
-            </a>
+              <li class="sub-navigation__item">
+                <a class="sub-navigation__link" href="{{submenu.call_to_action.slug}}">
+                  {{submenu.call_to_action.title}}
+                </a>
+              </li>
             {{/if}}
+            </ul>
           </div>
           {{/if}}
         </li>

--- a/src/components/navigation/navigation.hbs
+++ b/src/components/navigation/navigation.hbs
@@ -46,7 +46,12 @@
     <ul class="mobile-navigation__list">
       {{#each navigation}}
         <li class="js-nav-item mobile-navigation__item">
-          <a class="mobile-navigation__link"  href="{{slug}}">{{title}}</a>
+          <a class="mobile-navigation__link"  href="{{slug}}">{{title}}
+            {{#if submenu}}
+              <i class="icon icon--chevron-down"></i>
+            {{/if}}
+          </a>
+
 
           {{#if submenu.items.length}}
           <div class="mobile-sub-navigation">

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -30,7 +30,7 @@ class NavigationComponent extends Component {
     this.$mobileNavigation.on("click", ".js-close", this._clickNav.bind(this));
     this.$mobileNavigation.on("click", ".js-nav-item", this._handleClick.bind(this));
 
-    this.$el.on("click", ".js-nav-item", this._handleClick.bind(this));
+    this.$el.on("touchstart", ".js-nav-item", this._handleClick.bind(this));
 
     // SubNavigation hover
     this.handleHover();
@@ -49,19 +49,23 @@ class NavigationComponent extends Component {
 
   _handleClick(e) {
     let target = e.currentTarget;
-    if (target.text === "Shop") {
-      return;
-    }
-    e.preventDefault();
-    $(target).hasClass("navigation__link") ? this._openSubNav(target) : this._openMobileSubNav(target);
+    $(target).hasClass("navigation__item") ? this._handleSubNav(target) : this._handleMobileSubNav(target);
   }
 
-  _openMobileSubNav(el) {
+  _handleMobileSubNav(el) {
     let $navItem = $(el).find(".mobile-sub-navigation");
     if ( $(".is-expanded").length && !$navItem.hasClass("is-expanded") ) {
       this.$mobileNavigation.find(".mobile-sub-navigation").removeClass("is-expanded");
     }
     $navItem.toggleClass("is-expanded");
+  }
+
+  _handleSubNav(el) {
+    if ($(el).find(".sub-navigation").hasClass("sub-navigation--visible")) {
+      this._closeSubNav(el);
+    } else {
+      this._openSubNav(el);
+    }
   }
 
   _openSubNav(el) {
@@ -72,7 +76,7 @@ class NavigationComponent extends Component {
 
     this.showTimer = setTimeout(() => {
       $(el).find(".sub-navigation").addClass("sub-navigation--visible");
-    });
+    }, 0);
   }
 
   _closeSubNav(el) {

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -54,6 +54,8 @@ class NavigationComponent extends Component {
 
   _handleMobileSubNav(el) {
     let $navItem = $(el).find(".mobile-sub-navigation");
+    $(el).toggleClass("clicked");
+
     if ( $(".is-expanded").length && !$navItem.hasClass("is-expanded") ) {
       this.$mobileNavigation.find(".mobile-sub-navigation").removeClass("is-expanded");
     }

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -54,11 +54,13 @@ class NavigationComponent extends Component {
 
   _handleMobileSubNav(el) {
     let $navItem = $(el).find(".mobile-sub-navigation");
-    $(el).toggleClass("clicked");
 
     if ( $(".is-expanded").length && !$navItem.hasClass("is-expanded") ) {
       this.$mobileNavigation.find(".mobile-sub-navigation").removeClass("is-expanded");
+      this.$mobileNavigation.find(".js-nav-item").removeClass("clicked");
     }
+
+    $(el).toggleClass("clicked");
     $navItem.toggleClass("is-expanded");
   }
 


### PR DESCRIPTION
Fixes a few bugs introduced by first update that added dropdowns to the mobile nav and makes some design changes, per @bpotterbaum.

- Remove CTA from bookings dropdown
- Integrate CTA into mobile Destinations dropdown by removing blue background and arrow icon
- Move text for 'featured' section to right of img in Dest. mobile dropdown
- Add animated arrow icons to Dest. and Bookings items in mobile nav
- Fixed links not working when clicked
- Added touch event to open dropdowns in mobile
- Fixed bug of user dropdown not activating on click/hover

Goes with https://github.com/lonelyplanet/destinations-next/pull/483