### PR TITLE
Update framework for articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "sassdoc-theme-neat": "0.0.2",
     "sinon": "^1.17.1",
     "style-loader": "^0.13.0",
+    "susy": "^2.2.6",
     "webpack": "^1.12.2"
   }
 }

--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -32,7 +32,7 @@ body {
 }
 
 .container {
-  @include container();
+  @include container-padded();
 }
 
 .hide-text {

--- a/sass/_base_mixins.scss
+++ b/sass/_base_mixins.scss
@@ -75,6 +75,8 @@
 ///
 /// Includes Susy's container mixin.
 ///
+/// Should be used for the outermost container.
+///
 /// ### Modifiers (deprecated)
 /// * `--slim` removes the gutters
 /// * `--narrow` smaller width

--- a/sass/_base_mixins.scss
+++ b/sass/_base_mixins.scss
@@ -1,3 +1,4 @@
+/// ----------------------------------------------------------------------------
 /// Use to separate components on the page.
 /// ### Modifiers
 /// * `--grey` modifier to change the background color
@@ -6,6 +7,7 @@
 /// .segment {
 ///   @include segment();
 /// }
+/// ----------------------------------------------------------------------------
 @mixin segment() {
   margin: 0;
   padding-top: ($gutter * 2);
@@ -67,45 +69,125 @@
   }
 }
 
-/// Create a container element to wrap segments
-/// ### Modifiers
+/// ----------------------------------------------------------------------------
+/// Extends Susy by returning a container with gutters; requires
+/// [Susy](http://susy.oddbird.net/).
+///
+/// Includes Susy's container mixin.
+///
+/// ### Modifiers (deprecated)
 /// * `--slim` removes the gutters
 /// * `--narrow` smaller width
 /// * `--half` half of the max width
-@mixin container() {
-  margin-left: auto;
-  margin-right: auto;
-  max-width: $max-width;
+/// ----------------------------------------------------------------------------
+@mixin container-padded {
+  // Include Susy's container mixin
+  @include container;
 
-  @media (max-width: $max-480) {
-    padding-left: ($gutter / 2);
-    padding-right: ($gutter / 2);
+  // Tell Susy to use static values
+  @include with-layout(static) {
+    // Calculate the width of the container plus each gutter (doubled) and then
+    // convert the value to ems for use in the media query.
+    $max-width: container() + gutter-quad();
+    $media-query: #{(strip-units($max-width) * .625)}em;
+
+    @media (max-width: $max-480) {
+      padding-left: gutter-half();
+      padding-right: gutter-half();
+    }
+
+    @media (min-width: $min-480) {
+      margin-left: gutter();
+      margin-right: gutter();
+    }
+
+    @media (min-width: $min-1080) {
+      margin-left: gutter-double();
+      margin-right: gutter-double();
+    }
+
+    @media(min-width: $media-query) {
+      margin-left: auto;
+      margin-right: auto;
+    }
+
+    // These modifiers are deprecated as it's easy enough to use Susy's span
+    // function to calculate widths on demand.
+    &--slim {
+      max-width: span(10); // $max-width - 12rem - ($gutter * 2)
+    }
+
+    &--narrow {
+      max-width: span(9); // ($max-width - $min-width)
+    }
+
+    &--half {
+      max-width: span(6); // ($max-width / 2)
+    }
+  }
+}
+
+/// ----------------------------------------------------------------------------
+/// Extends Susy by returning a static width container with optional gutters;
+/// requires [Susy](http://susy.oddbird.net/).
+///
+/// @param  {Number} $span                      - Number of columns to span
+/// @param  {String} $position [inside]|outside - Inside: wrapped; outside:
+///                                               wrapping (see @example)
+/// @example:
+/// ```scss
+/// // position: inside (default)
+/// .outer-container {
+///   // Include Susy's default container for the outermost container
+///   @include container;
+///
+///   .inner-container {
+///     // Include the static-container mixin that spans 6 columns and is inside
+///     // of another container; since 'inside' is default, the argument
+///     // doesn't need to be passed.
+///     @include container-static(6);
+///   }
+/// }
+///
+/// // position: outside
+/// .outer-container {
+///   // Include the static container mixin that spans 6 columns and is the
+///   // outermost container. When set to 'outside', Susy's default container
+///   // mixin will be included.
+///   @include container-static(6, outside);
+/// }
+/// ----------------------------------------------------------------------------
+@mixin container-static($span, $position: inside) {
+  // Include Susy's container mixin if the static container is positioned on the
+  // outside, i.e., wrapping.
+  @if $position == outside {
+    @include container;
   }
 
-  @media (min-width: $min-480) {
-    margin-left: $gutter;
-    margin-right: $gutter;
-  }
+  // Tell Susy to use static values
+  @include with-layout(static) {
+    // Calculate the width of the container plus each gutter and then convert
+    // the value to ems for use in the media query.
+    $max-width: span($span) + gutter-double();
+    $mq: #{(strip-units($max-width) * .625)}em;
 
-  @media (min-width: $min-1080) {
-    margin-left: ($gutter * 2);
-    margin-right: ($gutter * 2);
-  }
+    // Add horizontal margins if the static contained is positioned on the
+    // outside, i.e., wrapping.
+    @if $position == outside {
+      margin-left: gutter();
+      margin-right: gutter();
+    }
 
-  @media (min-width: #{strip-units(($max-width + ($gutter * 4)) * .625)}em) {
-    margin-left: auto;
-    margin-right: auto;
-  }
+    @media(min-width: $mq) {
+      // Reset the horizontal margins to center the static container if it's
+      // positioned on the outside, i.e., wrapping.
+      @if $position == outside {
+        margin-left: auto;
+        margin-right: auto;
+      }
 
-  &--slim {
-    max-width: $max-width - 12rem - ($gutter * 2);
-  }
-
-  &--narrow {
-    max-width: $max-width - $min-width;
-  }
-
-  &--half {
-    max-width: ($max-width / 2);
+      // Set a static width with Susy's `span` function
+      width: span($span);
+    }
   }
 }

--- a/sass/_functions.scss
+++ b/sass/_functions.scss
@@ -19,3 +19,32 @@
 @function em($pixel, $base: 16px) {
   @return ($pixel / $base) * 1em;
 }
+
+/// An alias for `map-get`
+///
+/// @param  {Map}    $map - Map name
+/// @param  {String} $key - Key name
+/// @return {String}      - Key value
+@function get($map, $key) {
+  @return map-get($map, $key);
+}
+
+/// Half gutter; requires [Susy](http://susy.oddbird.net/)
+@function gutter-half() {
+  @return (gutter() / 2);
+}
+
+/// Quarter gutter; requires [Susy](http://susy.oddbird.net/)
+@function gutter-quarter() {
+  @return (gutter() / 4);
+}
+
+// Double gutter; requires [Susy](http://susy.oddbird.net/)
+@function gutter-double() {
+  @return (gutter() * 2);
+}
+
+// Quadruple gutter; requires [Susy](http://susy.oddbird.net/)
+@function gutter-quad() {
+  @return (gutter() * 4);
+}

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -17,6 +17,7 @@
 
 /// Set up a media query passing a value to use for min width
 ///
+/// @deprecated
 /// @param {number} $screen-width - A value for the media query
 /// @param {string} $method ['min'] - 'min' or 'max'
 /// @example sass
@@ -41,7 +42,7 @@
   padding-bottom: #{$ratioPercentage + %};
 }
 
-/// Hack to force GPU rendering (most in the community argue this should be used quite sparingly!!)
+/// Hack to force GPU rendering (most in the community argue this should be used quite sparingly!)
 @mixin hardware-acceleration() {
   z-index: 1;
   transform: translateZ(0);
@@ -80,6 +81,7 @@
 }
 
 /// Sets max width and centers component
+/// @deprecated
 @mixin component-width() {
   max-width: 1290px;
   margin: 0 auto;

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -70,6 +70,8 @@ $animation-speed: .4s;
 $animation-speed-ui: .8s;
 
 // Custom breakpoints (Mobile first)
+/// 1350px min width breakpoint
+$min-1350: #{(1350 * 0.0625)}em;
 /// 1290px min width breakpoint
 $min-1290: #{(1290 * 0.0625)}em;
 /// 1200px min width breakpoint
@@ -98,6 +100,7 @@ $min-360: #{(360 * 0.0625)}em;
 $min-320: #{(320 * 0.0625)}em;
 
 // Custom breakpoints
+$max-1350: #{(1349 * 0.0625)}em;
 $max-1290: #{(1289 * 0.0625)}em;
 $max-1200: #{(1199 * 0.0625)}em;
 $max-1080: #{(1079 * 0.0625)}em;
@@ -111,3 +114,24 @@ $max-560: #{(559 * 0.0625)}em;
 $max-480: #{(479 * 0.0625)}em;
 $max-360: #{(359 * 0.0625)}em;
 $max-320: #{(319 * 0.0625)}em;
+
+/// ----------------------------------------------------------------------------
+/// Layouts
+///
+/// Susy can be used to create multiple grid layouts. The `$default-layout`
+/// layout is mapped to the `$susy` variable, which is the required namespace
+/// within Susy for the default layout. View
+/// [Susy's documentation](http://susydocs.oddbird.net/en/latest/) to learn how
+/// to call other layouts and for accepted key/value pairs.
+/// ----------------------------------------------------------------------------
+$default-layout: (
+  columns: 12,
+  column-width: 8rem,
+  container: $max-width,
+  gutter-position: before,
+  gutters: 3/8,
+  math: fluid,
+  output: float
+);
+
+$susy: $default-layout;

--- a/sass/_webpack_deps.scss
+++ b/sass/_webpack_deps.scss
@@ -1,3 +1,5 @@
+@import "~susy/sass/susy";
+
 @import "functions";
 
 @import "variables";

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -6,7 +6,7 @@ $logo-height: 4rem;
   position: relative;
 
   @media (min-width: $min-960) {
-    @include container();
+    @include container-padded();
   }
 
   &__container {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -21,7 +21,7 @@
   }
 
   &__container {
-    @include container();
+    @include container-padded();
   }
 
   &__inner {

--- a/src/components/hotels/_hotels.scss
+++ b/src/components/hotels/_hotels.scss
@@ -44,7 +44,7 @@ $hotels-max-width: 1170;
 }
 
 .hotels__container {
-  @include container();
+  @include container-padded();
 }
 
 .hotels__header {

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -26,7 +26,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
   }
 
   &--no-images.masthead--narrow {
-    @include container();
+    @include container-padded();
     border: none;
     color: $font-color;
     height: 30rem;

--- a/src/components/slideshow/slideshow.scss
+++ b/src/components/slideshow/slideshow.scss
@@ -51,7 +51,7 @@
   }
 
   &--slide {
-    @include container();
+    @include container-padded();
 
     @media (min-width: $min-1290) {
       padding: 0;

--- a/src/components/sub_nav/_sub_nav.scss
+++ b/src/components/sub_nav/_sub_nav.scss
@@ -75,7 +75,7 @@ $navigation-sub-height-mobile: $header-height-mobile;
     }
 
     @media (min-width: $min-720) {
-      @include container();
+      @include container-padded();
 
       &:after {
         margin: 0;


### PR DESCRIPTION
This update introduces [Susy](http://susy.oddbird.net/) to Rizzo Next.

Rizzo Next is lacking a grid system. Susy fills that gap by providing the tools to allow us to create grids quickly and accurately. Susy is also very flexible because it allows for multiple layouts.

For example, Susy allows for the creation of a 3-column layout very easily, like so:

```scss
// Based on a 12-column grid

.wrap {
  @include container;
}

.left-sidebar {
  @include span(2);
}

.main {
  @include span(6);
}

.right-sidebar {
  @include span(4);
}
```

Susy's documentation can be found [here](http://susydocs.oddbird.net/en/latest/).

Note that a small breaking change has been made (see 6b321bb): the `container` mixin has been renamed to `container-padded` as Susy's `container` mixin clashes. However, all of the functionality that exists within the old `container` mixin has been retained for the new `container-padded` mixin. Also, since Susy's `container` mixin does not include horizontal margins or padding, the `container-padded` mixin is able to compliment Susy's `container` mixin nicely by providing us the ability to pad edges of the container when necessary. This means that the `container-padded` mixin is usually best suited for the outermost container, whereas Susy's `container` mixin would be best used for inner containers.