### PR TITLE
Add temp URL to slugs in sidebar details link.

### DIFF
--- a/src/components/map/views/about-panel.jsx
+++ b/src/components/map/views/about-panel.jsx
@@ -19,6 +19,7 @@ export default class AboutPanel extends React.Component {
   render() {
     let place = this.props.location.title,
         description = this.props.location.description,
+        // TODO Switch back to just ${this.props.location.slug} once this is live
         slug = `https://www.lonelyplanet.com/${this.props.location.slug}`;
 
     return (

--- a/src/components/map/views/sidebar-details.jsx
+++ b/src/components/map/views/sidebar-details.jsx
@@ -9,8 +9,10 @@ export default class SidebarDetailsView extends React.Component{
     $clamp(el, { clamp: 2 });
   }
   render() {
-    let poi = this.props.poi;
-    let image = "";
+    let poi = this.props.poi,
+        image = "";
+        // TODO Switch back to just ${poi.slug} once this is live
+        slug = `https://www.lonelyplanet.com/${poi.slug}`;
 
     if (poi.geo.properties.image) {
       let imgSrc = `http://images-resrc.staticlp.com/s=w470,pd1/o=85/${poi.geo.properties.image}`;
@@ -18,7 +20,7 @@ export default class SidebarDetailsView extends React.Component{
         <img src={imgSrc} ref="img" />
       </div>
     }
-    let slug = `/${poi.slug}`;
+
     return (
       <div className="sidebar details">
         <header className="sidebar__header">

--- a/src/components/map/views/sidebar-details.jsx
+++ b/src/components/map/views/sidebar-details.jsx
@@ -10,7 +10,7 @@ export default class SidebarDetailsView extends React.Component{
   }
   render() {
     let poi = this.props.poi,
-        image = "";
+        image = "",
         // TODO Switch back to just ${poi.slug} once this is live
         slug = `https://www.lonelyplanet.com/${poi.slug}`;
 


### PR DESCRIPTION
This was already done for the 'about' panel; Added it to sidebar details also. This is a temp fix to keep beta users from experiencing errors when linking to pages outside of Destinations