### PR TITLE
Add Continent navigation to masthead

### DIFF
--- a/src/components/masthead/_masthead_nav.scss
+++ b/src/components/masthead/_masthead_nav.scss
@@ -1,8 +1,9 @@
 @import "../../../sass/webpack_deps";
 
 .masthead_nav {
-  position: relative;
-  bottom: 6rem;
+  position: absolute;
+  bottom: 0;
+  width: 100%;
   z-index: 100;
   color: #fff;
 

--- a/src/components/masthead/_masthead_nav.scss
+++ b/src/components/masthead/_masthead_nav.scss
@@ -1,0 +1,41 @@
+@import "../../../sass/webpack_deps";
+
+.masthead_nav {
+  position: relative;
+  bottom: 6rem;
+  z-index: 100;
+  color: #fff;
+
+  &__container {
+    @include container();
+    border-top: .1rem solid rgba(255,255,255, .3);
+    height: 6rem;
+  }
+
+  &__link {
+    color: #fff;
+    font-size: 1.2rem;
+    line-height: 6rem;
+    text-transform: uppercase;
+
+    [class*="icon-chevron"] {
+      font-size: 6px;
+      vertical-align: 35%;
+    }
+
+  }
+
+  .left {
+    i {
+      margin-right: 1.6rem
+    }
+  }
+
+  .right {
+    float: right;
+
+    i {
+      margin-left: 1.6rem
+    }
+  }
+}

--- a/src/components/masthead/index.js
+++ b/src/components/masthead/index.js
@@ -1,5 +1,6 @@
 import Masthead from "./masthead_component";
 
 require("./_masthead.scss");
+require("./_masthead_nav.scss");
 
 export default Masthead;

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -46,6 +46,9 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
       </div>
     </div>
   </div>
+  {{#if is_continent}}
+    {{> "components/masthead/masthead_nav" }}
+  {{/if}}
 
   {{#if top_places}}
     {{> "components/top_places/top_places" }}

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -1,5 +1,6 @@
 import { Component } from "../../core/bane";
 import Slideshow from "../slideshow";
+import MastheadNav from "./masthead_nav.js";
 import assign from "lodash/object/assign";
 import Overlay from "../overlay";
 

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -1,8 +1,8 @@
 import { Component } from "../../core/bane";
 import Slideshow from "../slideshow";
-import MastheadNav from "./masthead_nav.js";
 import assign from "lodash/object/assign";
 import Overlay from "../overlay";
+import "./masthead_nav.js";
 
 /**
  * Masthead Component

--- a/src/components/masthead/masthead_nav.hbs
+++ b/src/components/masthead/masthead_nav.hbs
@@ -1,11 +1,11 @@
 <section class="masthead_nav">
   <div class="masthead_nav__container">
-  <a href="#" class="masthead_nav__link left">
+  <a href="{{prev.slug}}" class="masthead_nav__link left">
     <i class="icon-chevron-left"></i>
-    Continent
+    {{prev.title}}
   </a>
-  <a href="#" class="masthead_nav__link right">
-    caribbean
+  <a href="{{next.slug}}" class="masthead_nav__link right">
+    {{next.title}}
     <i class="icon-chevron-right"></i>
   </a>
   </div>

--- a/src/components/masthead/masthead_nav.hbs
+++ b/src/components/masthead/masthead_nav.hbs
@@ -1,0 +1,12 @@
+<section class="masthead_nav">
+  <div class="masthead_nav__container">
+  <a href="#" class="masthead_nav__link left">
+    <i class="icon-chevron-left"></i>
+    Continent
+  </a>
+  <a href="#" class="masthead_nav__link right">
+    caribbean
+    <i class="icon-chevron-right"></i>
+  </a>
+  </div>
+</section>

--- a/src/components/masthead/masthead_nav.js
+++ b/src/components/masthead/masthead_nav.js
@@ -1,0 +1,7 @@
+require("./_masthead_nav.scss");
+
+let MastheadNav = {
+
+}
+
+export default MastheadNav;

--- a/src/components/masthead/masthead_nav.js
+++ b/src/components/masthead/masthead_nav.js
@@ -1,7 +1,1 @@
 require("./_masthead_nav.scss");
-
-let MastheadNav = {
-
-}
-
-export default MastheadNav;


### PR DESCRIPTION
Creates a new feature within Masthead that allows the user to navigate to the previous or next continent, in the same order as the list of continents in the nav bar drop down. 

Relies on https://github.com/lonelyplanet/destinations-next/pull/488

![screen shot 2015-11-11 at 1 54 14 pm](https://cloud.githubusercontent.com/assets/3247835/11101274/bdc03322-887b-11e5-89fe-b93badf7a3c2.png)
