### PR TITLE
Add min-height to food and drink

### DIFF
--- a/src/components/food_and_drink/_food_and_drink.scss
+++ b/src/components/food_and_drink/_food_and_drink.scss
@@ -12,6 +12,14 @@ $item-border-color: #f1f4fb;
   margin-bottom: $spacing;
   font-weight: $medium;
 
+  @media (min-width: $min-960) {
+    min-height: 400px;
+  }
+
+  @media (min-width: $min-1080) {
+    min-height: 425px;
+  }
+
   &__heading {
     @include h1();
   }


### PR DESCRIPTION
In some edge cases, taller food and drink images were cut off when a place had only one or two food/drink POIs. Adding a min height to the component above 960px helps keep the container from collapsing to too narrow a space to fit the image.
Before:
<img width="617" alt="screen shot 2015-11-12 at 2 33 37 pm" src="https://cloud.githubusercontent.com/assets/3247835/11130406/6ff5201a-894a-11e5-9d1e-f281109e5b12.png">
After:
<img width="969" alt="screen shot 2015-11-12 at 2 30 33 pm" src="https://cloud.githubusercontent.com/assets/3247835/11130408/76a6c22e-894a-11e5-9dd9-e4198c07b9a4.png">

