### PR TITLE
Strapline bugfixes

### DIFF
--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -164,10 +164,9 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
   }
 
   &__title {
-    margin-bottom: 1rem;
     font-size: 5.6rem;
     font-weight: 600;
-    line-height: 1;
+    line-height: .9;
     letter-spacing: -.3rem;
 
     @media (min-width: $min-560) {

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -222,21 +222,21 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     }
 
     &:empty {
-      display: none;
+      // display: none;
     }
   }
 
   &__straplines.has-empty &__strapline--visible {
     position: relative;
-  }
-
-  &__straplines.has-empty &__strapline:not(:empty) {
     height: $masthead-straplines-height-small;
-    transition: height ($animation-speed-ui * 2) ease-in-out;
 
     @media (min-width: $min-720) {
       height: $masthead-straplines-height-large;
     }
+  }
+
+  &__straplines.has-empty &__strapline:not(:empty) {
+    transition: height ($animation-speed-ui * 2) ease-in-out;
   }
 
   &__button {


### PR DESCRIPTION
In cases where a city has more images than strap lines, the masthead text would jump to a different height when transitioning from images with strap lines to those without. This fix keeps the text in place whether `.strapline` is empty or not. I have tested the change against cities with no empty strap lines, continents, and countries. No behavior changes found in desktop or mobile views.

Also  Reduce spacing between masthead title and strapline
per https://trello.com/c/ImHr3Ell/465-title-and-strapline-tweek