### PR TITLE
Add 'see more' link to hotels

### DIFF
--- a/src/components/hotels/_hotels.scss
+++ b/src/components/hotels/_hotels.scss
@@ -13,6 +13,7 @@ $hotels-max-width: 1170;
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
+  position: relative;
 
   // Override segment() padding
   padding-top: ($gutter*2) - .6rem;
@@ -39,6 +40,21 @@ $hotels-max-width: 1170;
     select,
     tbody {
       color: $font-color;
+    }
+  }
+
+  &__button-container {
+    position: absolute;
+    left: calc(50% - (76px / 2));
+    bottom: 114px;
+  }
+
+  &__more {
+    @include more();
+    color: #fff;
+
+    &:hover {
+      color: #fff;
     }
   }
 }

--- a/src/components/hotels/hotels.hbs
+++ b/src/components/hotels/hotels.hbs
@@ -46,7 +46,12 @@
           <button class="hotels__search__button" id="js-hotels-submit" type="submit">Search</button>
         </fieldset>
       </form>
-
+    </div>
+    <div class="hotels__button-container">
+      <a class="hotels__more" href="http://www.lonelyplanet.com/{{slug}}/hotels">
+        See More
+        <i class="icon-chevron-right" aria-hidden="true"></i>
+      </a>
     </div>
   </section>
 {{/if}}


### PR DESCRIPTION
Allows users to go directly to the hotels list page for a city without entering search criteria. 
![screen shot 2015-11-16 at 12 03 04 pm](https://cloud.githubusercontent.com/assets/3247835/11190200/062d74c6-8c5a-11e5-8dbb-9abffb39ed06.png)
