### PR TITLE
Update nav login button to show border in city views; fix typo

### DIFF
--- a/src/components/navigation/_navigation.scss
+++ b/src/components/navigation/_navigation.scss
@@ -46,6 +46,19 @@
         padding: 0;
         border: none;
       }
+
+      .navigation--narrow & {
+        @include buttonBorder($font-color)
+
+        &:hover {
+          border-color: $color-primary;
+        }
+
+        &.avatar {
+          padding: 0;
+          border: none;
+        }
+      }
     }
   }
 

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -149,7 +149,7 @@ class NavigationComponent extends Component {
       return $li.html($("<a />", {
         "class": "navigation__link",
         "href": "https://auth.lonelyplanet.com/users/sign_in"
-      }).text("Sign In"));
+      }).text("Sign in"));
     }
 
     $li.html(userPanelTemplate({


### PR DESCRIPTION
Changed "Log In" to "Log in". Added dark border around it when in city view.
unhovered:
<img width="192" alt="screen shot 2015-11-17 at 3 08 39 pm" src="https://cloud.githubusercontent.com/assets/3247835/11224960/24005a34-8d3d-11e5-850d-011fd68477a3.png">
hovered:
<img width="172" alt="screen shot 2015-11-17 at 3 08 46 pm" src="https://cloud.githubusercontent.com/assets/3247835/11224963/29897a58-8d3d-11e5-8a8a-8c144c32aae5.png">

