### PR TITLE
Bump node-sass to fix includePaths

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "ci": "karma start",
-    "docs": "node-sass sass/docs.scss -o dist/css && esdoc -c esdoc.json",
+    "docs": "node-sass sass/docs.scss -o dist/css --include-path=node_modules && esdoc -c esdoc.json",
     "sassdoc": "./node_modules/.bin/sassdoc sass --theme neat",
     "lint": "./node_modules/.bin/eslint src --ext .js,.jsx"
   },
@@ -66,7 +66,7 @@
     "karma-sinon": "^1.0.4",
     "karma-webpack": "^1.7.0",
     "mocha": "^2.2.5",
-    "node-sass": "^3.4.1",
+    "node-sass": "^3.4.2",
     "object-assign": "^3.0.0",
     "phantomjs": "^1.9.17",
     "sass-loader": "^3.1.1",

--- a/sass/_webpack_deps.scss
+++ b/sass/_webpack_deps.scss
@@ -1,4 +1,4 @@
-@import "~susy/sass/susy";
+@import "susy/sass/susy";
 
 @import "functions";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,8 +28,8 @@ module.exports = {
       {
         // For some reason the sass-loader borks karma
         test: /\.scss$/,
-        loader: "file"
-        // loader: "style!css!sass"
+        // loader: "file"
+        loader: "style!css!sass?includePaths[]=" + path.join(__dirname, "node_modules")
       },
       {
         test: /\.hbs$/,


### PR DESCRIPTION
I don't *love* the *~* syntax for the `sass-loader` because it couples our sass to WebPack.

There was a bug in `node-sass` that this upgrade fixes so that the `includePaths` option works as expected.