### PR TITLE
Destinations beta opt-out banner

### DIFF
--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -458,3 +458,14 @@
   top: 0;
   width: $width;
 }
+
+// alert component background colors
+$alert-colors: (
+  "warning": red,
+  "notice": yellow,
+  "default": #3b444f
+);
+
+@mixin alert-background($color: "default") {
+  background-color: map-get($alert-colors, $color);
+}

--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -1,29 +1,51 @@
 @import "../../../sass/webpack_deps";
 
 .alert {
+  $alert-font-color: #fff;
+  max-height: 0;
+  overflow-y: hidden;
+  transition: max-height 500ms;
+
+  &--is-visible {
+    max-height: 8rem;
+  }
 
   &__container {
     text-align: center;
+    padding: {
+      right: 2rem;
+      left: 2rem;
+    }
+
+    &--default {
+      @include alert-background($color:"default");
+    }
+    &--warning {
+      @include alert-background($color:"warning");
+    }
+    &--notice {
+      @include alert-background($color:"notice");
+    }
   }
 
   &__inner {
+    color: $alert-font-color;
     font-size: 1.4rem;
-    font-weight: $font-weight-light;
     padding: {
       top: 2.2rem;
       bottom: 2.2rem;
     }
 
     &--link {
-      color: $font-color;
-      font-weight: $font-weight-light;
+      color: $alert-font-color;
       text-decoration: underline;
     }
   }
 
   &__close {
     font-size: 0;
-    color: $font-color;
+    float: right;
+    color: $alert-font-color;
     font-weight: $font-weight-light;
     background-color: transparent;
     border: 0;

--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -4,10 +4,10 @@
   $alert-font-color: #fff;
   max-height: 0;
   overflow-y: hidden;
-  transition: max-height 500ms;
+  transition: max-height 600ms;
 
   &--is-visible {
-    max-height: 8rem;
+    max-height: 6.5rem;
   }
 
   &__container {
@@ -58,7 +58,7 @@
     &:hover,
     &:active,
     &:focus {
-      color: $color-primary;
+      color: #BEBEBE;
     }
 
     &:before {

--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -1,0 +1,47 @@
+@import "../../../sass/webpack_deps";
+
+.alert {
+
+  &__container {
+    text-align: center;
+  }
+
+  &__inner {
+    font-size: 1.4rem;
+    font-weight: $font-weight-light;
+    padding: {
+      top: 2.2rem;
+      bottom: 2.2rem;
+    }
+
+    &--link {
+      color: $font-color;
+      font-weight: $font-weight-light;
+      text-decoration: underline;
+    }
+  }
+
+  &__close {
+    font-size: 0;
+    color: $font-color;
+    font-weight: $font-weight-light;
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    height: 2rem;
+    cursor: pointer;
+    transition: color $animation-speed;
+    outline: 0;
+
+    &:hover,
+    &:active,
+    &:focus {
+      color: $color-primary;
+    }
+
+    &:before {
+      font-size: 1.2rem;
+    }
+  }
+
+}

--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,0 +1,8 @@
+<section class="alert">
+  <div class="alert__container" data-alert-color="red">
+    <div class="alert__inner">
+      {{ alert_text }}<a class="alert__inner--link" href="{{ url }}">{{ alert_link_text }}</a>
+      <button class="alert__close icon-close-small js-close">Close</button>
+    </div>
+  </div>
+</section>

--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,7 +1,7 @@
-<section class="alert alert--is-visible">
+<section class="alert">
   <div class="alert__container alert__container--{{ alert_type }}">
     <div class="alert__inner">
-      {{ alert_text }} <a class="alert__inner--link" href="{{ url }}">{{ alert_link_text }}</a>
+      {{ alert_text }} <a class="js-alert-link alert__inner--link" href="#">{{ alert_link_text }}</a>
       <button class="alert__close icon-close-small js-close">Close</button>
     </div>
   </div>

--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,8 +1,9 @@
-<section class="alert">
-  <div class="alert__container" data-alert-color="red">
+<section class="alert alert--is-visible">
+  <div class="alert__container alert__container--{{ alert_type }}">
     <div class="alert__inner">
-      {{ alert_text }}<a class="alert__inner--link" href="{{ url }}">{{ alert_link_text }}</a>
+      {{ alert_text }} <a class="alert__inner--link" href="{{ url }}">{{ alert_link_text }}</a>
       <button class="alert__close icon-close-small js-close">Close</button>
     </div>
   </div>
 </section>
+

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -1,26 +1,59 @@
 import Component from "../../core/component";
+import CookieUtil from "../../core/cookie_util";
+import subscribe from "../../core/decorators/subscribe";
 import waitForTransition from "../../core/utils/waitForTransition";
+import RizzoEvents from "../../core/rizzo_events";
 // import $ from "jquery";
+
 require("./_alert.scss");
 
 class Alert extends Component {
+
   initialize() {
-    this.events = {
-      "click .js-close": (e) => {
-        e.preventDefault();
-        console.log("close click");
-        this.hide();
-      }
+
+    this.cookieUtil = new CookieUtil();
+    if (this.cookieUtil.getCookie("dn-opt-in")) {
+      return;
     }
+
+    this.alert = {
+      alert_type: "default",
+      alert_text: "Rerturn to old Experience",
+      alert_link_text: "Leave beta"
+    };
+
+    this.template = require("./alert.hbs");
+    this.$el.prepend($(this.template(this.alert)));
+    this.$alert = this.$el.find(".alert");
+    // setTimeout(this.show.bind(this), 0);
+    // this.$alert.addClass("alert--is-visible");
+
+    this.events = {
+      "click .js-close": "hideAlert",
+      "click .js-alert-link": "removeCookies"
+    };
+
+    this.subscribe();
+  }
+  @subscribe(RizzoEvents.LOAD_BELOW, "events")
+  show() {
+    this.$alert.addClass("alert--is-visible");
   }
 
-  hide() {
-    this.$el.removeClass("alert--is-visible");
-
-    return waitForTransition(this.$el, { fallbackTime: 1000 })
+  hideAlert() {
+    this.cookieUtil.setCookie("dn-opt-in", "true", 30);
+    alert.removeClass("alert--is-visible");
+    return waitForTransition(alert, { fallbackTime: 1000 })
       .then(() => {
-        this.$el.detach();
+        alert.detach();
       });
+  }
+
+  removeCookies(e) {
+    e.preventDefault();
+    this.cookieUtil.removeCookie("_v");
+    this.cookieUtil.removeCookie("destinations-next-cookie");
+    location.reload();
   }
 }
 

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -31,6 +31,7 @@ class Alert extends Component {
 
     this.subscribe();
   }
+
   @subscribe(RizzoEvents.LOAD_BELOW, "events")
   show() {
     this.$alert.addClass("alert--is-visible");

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -1,1 +1,27 @@
+import Component from "../../core/component";
+import waitForTransition from "../../core/utils/waitForTransition";
+// import $ from "jquery";
 require("./_alert.scss");
+
+class Alert extends Component {
+  initialize() {
+    this.events = {
+      "click .js-close": (e) => {
+        e.preventDefault();
+        console.log("close click");
+        this.hide();
+      }
+    }
+  }
+
+  hide() {
+    this.$el.removeClass("alert--is-visible");
+
+    return waitForTransition(this.$el, { fallbackTime: 1000 })
+      .then(() => {
+        this.$el.detach();
+      });
+  }
+}
+
+export default Alert;

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -3,14 +3,12 @@ import CookieUtil from "../../core/cookie_util";
 import subscribe from "../../core/decorators/subscribe";
 import waitForTransition from "../../core/utils/waitForTransition";
 import RizzoEvents from "../../core/rizzo_events";
-// import $ from "jquery";
 
 require("./_alert.scss");
 
 class Alert extends Component {
 
   initialize() {
-
     this.cookieUtil = new CookieUtil();
     if (this.cookieUtil.getCookie("dn-opt-in")) {
       return;
@@ -25,8 +23,6 @@ class Alert extends Component {
     this.template = require("./alert.hbs");
     this.$el.prepend($(this.template(this.alert)));
     this.$alert = this.$el.find(".alert");
-    // setTimeout(this.show.bind(this), 0);
-    // this.$alert.addClass("alert--is-visible");
 
     this.events = {
       "click .js-close": "hideAlert",
@@ -42,10 +38,10 @@ class Alert extends Component {
 
   hideAlert() {
     this.cookieUtil.setCookie("dn-opt-in", "true", 30);
-    alert.removeClass("alert--is-visible");
-    return waitForTransition(alert, { fallbackTime: 1000 })
+    this.$alert.removeClass("alert--is-visible");
+    return waitForTransition(this.$alert, { fallbackTime: 1000 })
       .then(() => {
-        alert.detach();
+        this.$alert.detach();
       });
   }
 

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -1,0 +1,1 @@
+require("./_alert.scss");

--- a/src/components/masthead/masthead_nav.hbs
+++ b/src/components/masthead/masthead_nav.hbs
@@ -1,10 +1,10 @@
 <section class="masthead_nav">
   <div class="masthead_nav__container">
-  <a href="{{prev.slug}}" class="masthead_nav__link left">
+  <a href="/{{prev.slug}}" class="masthead_nav__link left">
     <i class="icon-chevron-left"></i>
     {{prev.title}}
   </a>
-  <a href="{{next.slug}}" class="masthead_nav__link right">
+  <a href="/{{next.slug}}" class="masthead_nav__link right">
     {{next.title}}
     <i class="icon-chevron-right"></i>
   </a>

--- a/src/core/cookie_util.js
+++ b/src/core/cookie_util.js
@@ -23,7 +23,7 @@ export default class CookieUtil {
   /**
    * Set a cookie
    * @param {String} k Cookie name
-   * @param {String} v Cookie value      
+   * @param {String} v Cookie value
    * @param {[Number]} days Expiration in days
    * @param {[String]} domain Domain of the cookie
    * @param {[String]} path Path of the cookie
@@ -41,11 +41,19 @@ export default class CookieUtil {
     path = ";path=" + (path || "/");
 
     let cookie = k + "=" + v + exp + domain + path;
-    
+
     // Explicit test for null here because of default argument above
-    return (this.cookies !== null ? 
-      (this.cookies = cookie) : 
+    return (this.cookies !== null ?
+      (this.cookies = cookie) :
       (document.cookie = cookie)
     );
+  }
+  removeCookie(name) {
+    let cookieString = `${name}=`;
+    let expiryDate = new Date();
+    expiryDate.setTime(expiryDate.getTime() - 86400 * 1000);
+    cookieString += ";max-age=0";
+    cookieString += `;expires=${expiryDate.toUTCString()}`;
+    document.cookie = cookieString;
   }
 }


### PR DESCRIPTION
Adds a banner to top of page that allows Destinations Next beta users to opt out and return to the original experience. Also has a 'close' button that will hide the banner and set a cookie to prevent showing the banner again.