### PR TITLE
Remove reveal animation on div. Add to text;

### DIFF
--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -4,7 +4,7 @@
   $alert-font-color: #fff;
   max-height: 0;
   overflow-y: hidden;
-  transition: max-height 600ms;
+  transition: max-height 500ms;
 
   &--is-visible {
     max-height: 6.5rem;
@@ -31,9 +31,15 @@
   &__inner {
     color: $alert-font-color;
     font-size: 1.4rem;
+    opacity: 0;
+    transition: opacity 100ms;
     padding: {
       top: 2.2rem;
       bottom: 2.2rem;
+    }
+
+    &--is-visible {
+      opacity: 1;
     }
 
     &--link {

--- a/src/components/alert/_alert.scss
+++ b/src/components/alert/_alert.scss
@@ -4,9 +4,13 @@
   $alert-font-color: #fff;
   max-height: 0;
   overflow-y: hidden;
-  transition: max-height 500ms;
+  transition: max-height $animation-speed;
 
-  &--is-visible {
+  .no-js & {
+    display: none;
+  }
+
+  &.is-visible {
     max-height: 6.5rem;
   }
 
@@ -38,7 +42,7 @@
       bottom: 2.2rem;
     }
 
-    &--is-visible {
+    &.is-visible {
       opacity: 1;
     }
 

--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,7 +1,7 @@
-<section class="alert">
+<section class="alert alert--is-visible">
   <div class="alert__container alert__container--{{ alert_type }}">
     <div class="alert__inner">
-      {{ alert_text }} <a class="js-alert-link alert__inner--link" href="#">{{ alert_link_text }}</a>
+      {{ alert_text }} <a class="js-alert-link alert__inner--link" href="#">{{ alert_link_text }}</a>.
       <button class="alert__close icon-close-small js-close">Close</button>
     </div>
   </div>

--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,4 +1,4 @@
-<section class="alert alert--is-visible">
+<section class="alert is-visible">
   <div class="alert__container alert__container--{{ alert_type }}">
     <div class="alert__inner">
       {{ alert_text }} <a class="js-alert-link alert__inner--link" href="#">{{ alert_link_text }}</a>.

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -34,12 +34,12 @@ class Alert extends Component {
 
   @subscribe(RizzoEvents.LOAD_BELOW, "events")
   show() {
-    this.$alert.find(".alert__inner").addClass("alert__inner--is-visible");
+    this.$alert.find(".alert__inner").addClass("is-visible");
   }
 
   hideAlert() {
     this.cookieUtil.setCookie("dn-opt-in", "true", 30);
-    this.$alert.removeClass("alert--is-visible");
+    this.$alert.removeClass("is-visible");
     return waitForTransition(this.$alert, { fallbackTime: 1000 })
       .then(() => {
         this.$alert.detach();

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -16,7 +16,7 @@ class Alert extends Component {
 
     this.alert = {
       alert_type: "default",
-      alert_text: "Return to old experience",
+      alert_text: "Return to old experience?",
       alert_link_text: "Leave beta"
     };
 
@@ -34,7 +34,7 @@ class Alert extends Component {
 
   @subscribe(RizzoEvents.LOAD_BELOW, "events")
   show() {
-    this.$alert.addClass("alert--is-visible");
+    this.$alert.find(".alert__inner").addClass("alert__inner--is-visible");
   }
 
   hideAlert() {


### PR DESCRIPTION
This tweaks the styling for the beta opt-in/out banner. It was decided that having the banner animate open for every new page load would be a poor user experience. Animating the opacity of the text helps mitigate the "pop-in" effect from rendering on the client side a little bit.