### PR TITLE
Fix iPad scrolling issue in maps panel

### DIFF
--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -271,7 +271,7 @@ $panel-height: calc(100% - #{$sidebar-header-height});
       position: absolute;
       top: auto;
       bottom: 0;
-      width: 100%;
+      width: $sidebar-width;
       box-shadow: 0 0 6rem 0 rgba(0,0,0,.08);
     }
 

--- a/src/components/map/views/about-panel.jsx
+++ b/src/components/map/views/about-panel.jsx
@@ -18,9 +18,7 @@ export default class AboutPanel extends React.Component {
   }
   render() {
     let place = this.props.location.title,
-        description = this.props.location.description,
-        // TODO Switch back to just ${this.props.location.slug} once this is live
-        slug = `https://www.lonelyplanet.com/${this.props.location.slug}`;
+        description = this.props.location.description;
 
     return (
       <div className="panel">
@@ -29,12 +27,6 @@ export default class AboutPanel extends React.Component {
         <header className="panel__header">Welcome to {place}</header>
         <div className="panel__content" dangerouslySetInnerHTML={{__html: description}}>
         </div>
-        <footer className="panel__footer">
-          <a className="panel__close" href={slug}>
-            Close map and explore this destination
-            <i className="icon-chevron-right" aria-hidden="true"></i>
-          </a>
-        </footer>
       </div>
     );
   }

--- a/src/components/map/views/sidebar-details.jsx
+++ b/src/components/map/views/sidebar-details.jsx
@@ -21,6 +21,8 @@ export default class SidebarDetailsView extends React.Component{
       </div>;
     }
 
+    let footer = <div className="panel__footer dooda"><a className="panel__close" href={slug}>Close map and explore this destination<span className="icon-chevron-right"></span></a></div>;
+
     return (
       <div className="sidebar details">
         <header className="sidebar__header">
@@ -32,13 +34,8 @@ export default class SidebarDetailsView extends React.Component{
         <div className="panel">
           {image}
           <div className="panel__content" dangerouslySetInnerHTML={{__html: poi.description}}></div>
-          <div className="panel__footer">
-            <a className="panel__close" href={slug}>
-              Close map and explore this destination
-              <span className="icon-chevron-right"></span>
-            </a>
-          </div>
         </div>
+        {footer}
       </div>
     );
   }

--- a/src/components/map/views/sidebar.jsx
+++ b/src/components/map/views/sidebar.jsx
@@ -17,7 +17,10 @@ export default class SidebarView extends React.Component {
         sets = this.props.sets,
         backSlug = "",
         backElement = "",
-        h1Class = "sidebar__title __continent";
+        h1Class = "sidebar__title __continent",
+        footer,
+        // TODO Switch back to just ${this.props.location.slug} once this is live
+        slug = `https://www.lonelyplanet.com/${this.props.location.slug}`;
 
     let tabs = sets.map((set, i) => {
       tabCount++;
@@ -43,6 +46,7 @@ export default class SidebarView extends React.Component {
     } else {
       if( this.props.customPanel === "about" ) {
         panelContent = <AboutPanel location={location} />;
+        footer = <footer className="panel__footer monkey"><a className="panel__close" href={slug}>Close map and explore this destination<i className="icon-chevron-right" aria-hidden="true"></i></a></footer>;
       } else {
         let activePanel = sets[this.props.activeSetIndex];
         panelContent = <Panel highlightedPoi={this.props.highlightedPoi} set={activePanel} />;
@@ -67,6 +71,7 @@ export default class SidebarView extends React.Component {
           </ul>
         </header>
         {panelContent}
+        {footer}
       </div>
     );
   }


### PR DESCRIPTION
Having the footer in the panel div caused issues in iPads where the footer would not stay fixed to the bottom. Having the footer rendered by handlebars instead of hardcoding it into the template allowed the footer to be 'outside' of the panel div and overcomes the scrolling problem.