### PR TITLE
Tweak hotels btn css to work in IE

### DIFF
--- a/src/components/hotels/_hotels.scss
+++ b/src/components/hotels/_hotels.scss
@@ -180,6 +180,11 @@ $hotels-max-width: 1170;
     border-color: rgba($hotels-color, .66);
   }
 
+  // hide select dropdown arrow in IE10 +
+  &::-ms-expand {
+    display: none;
+  }
+
   option {
     color: $darkgray;
   }
@@ -202,6 +207,6 @@ $hotels-max-width: 1170;
 
   @media (min-width: $hotels-breakpoint-large-min) {
     width: 180px;
-    margin-left: 21px;
+    margin-left: 20px;
   }
 }


### PR DESCRIPTION
The margin on the search button was exactly one pixel too wide to work in IE. Reducing it keeps it from jumping below the form inputs. Also needed to add an IE-specific style to hide the HTML5 select dropdown arrow icon.

Before:
![10qpb](https://cloud.githubusercontent.com/assets/3247835/11375723/5dd01276-92a2-11e5-996f-5a74b7da8b5e.png)
After:
![screen shot 2015-11-24 at 11 56 36 am](https://cloud.githubusercontent.com/assets/3247835/11375732/7514ed30-92a2-11e5-9c80-f781de7f83e9.png)
