### PR TITLE
Add matchMedia utility to core

### DIFF
--- a/src/core/utils/matchMedia.js
+++ b/src/core/utils/matchMedia.js
@@ -1,0 +1,26 @@
+/**
+ * Checks against a specified media query string. Adds a listener for
+ * `matchMedia` and runs a callback function when the media query matches.
+ * @param  {String}   query    Media query to listen for
+ * @param  {Function} callback Callback function to run when the query
+ *                             matches.
+ * @example
+ * import matchMedia from "../../core/utils/matchMedia";
+ *
+ * matchMedia("(min-width: 720px)", (query) => {
+ *   if (query.matches) {
+ *     // do this
+ *   } else {
+ *     // do that
+ *   }
+ * });
+ */
+export default function(query, callback) {
+  let query = window.matchMedia(query);
+
+  if (typeof callback === "function") {
+    query.addListener(callback);
+
+    callback(query);
+  }
+}

--- a/src/core/utils/matchMedia.js
+++ b/src/core/utils/matchMedia.js
@@ -16,11 +16,11 @@
  * });
  */
 export default function(query, callback) {
-  let query = window.matchMedia(query);
+  let media = window.matchMedia(query);
 
   if (typeof callback === "function") {
-    query.addListener(callback);
+    media.addListener(callback);
 
-    callback(query);
+    callback(media);
   }
 }


### PR DESCRIPTION
This utility uses the [window.matchMedia](https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia) method to match a media query string. It will allow conditional loading of components or pieces of components based on a media query.

Browser support is pretty good, but it will need to be polyfilled for IE 9 and Opera Mini 8. See http://caniuse.com/#feat=matchmedia

Usage is documented in the code, but it's very straight forward:

```js
import matchMedia from "../../core/utils/matchMedia";

matchMedia("(min-width: 720px)", (query) => {
  if (query.matches) {
    // do this
  } else {
    // do that
  }
});
```