### PR TITLE
Article POI callout

### DIFF
--- a/sass/_color_variables.scss
+++ b/sass/_color_variables.scss
@@ -22,3 +22,4 @@ $tours-blurb-color: #a0a6ad !default;
 $tours-price-background: #dc1b10 !default;
 $tours-title-color: #474f5a !default;
 $tours-type-color: #c4c7cb !default;
+$dark-blue: #2b3542 !default;

--- a/sass/typography/_links_mixins.scss
+++ b/sass/typography/_links_mixins.scss
@@ -59,33 +59,70 @@
 }
 
 /// Provides the underline for the fancy link
-/// @param {Color} $color [$color-blue] - Color of the underline (usually same as the text color)
+/// @param {Color} $color [$color-blue] - Color of the underline, usually the same as the text color
+/// @param {Color} $background-color [#fff] Background color of the underline, usually the same color as the page; used for underline styles not solid
 /// @param {Dimension} $weight [.1rem] - Width of the underline
 /// @param {Dimension} $offset [.2rem] - Amount of padding above the underline
+/// @param {String} $style [solid] The underline style can be solid, dashed or dotted
 @mixin underline(
   $color: $color-blue,
+  $background-color: #fff,
   $weight: .1rem,
-  $offset: .2rem
+  $offset: .2rem,
+  $style: solid
 ) {
-  background-image: linear-gradient(to top, transparent, transparent $offset, $color $offset, $color ($offset + $weight), transparent ($offset + $weight));
+  $underline: linear-gradient(to top, transparent, transparent $offset, $color $offset, $color ($offset + $weight), transparent ($offset + $weight));
+
+  @if $style == solid {
+    background-image: $underline;
+  }
+
+  @if $style == dashed {
+    background-image:
+      repeating-linear-gradient(to right, rgba($background-color, 0), rgba($background-color, 0) .3rem, $background-color .3rem, $background-color .6rem),
+      $underline;
+  }
+
+  @if $style == dotted {
+    background-image:
+      repeating-linear-gradient(to right, rgba($background-color, 0), rgba($background-color, 0) .1rem, $background-color .1rem, $background-color .2rem),
+      $underline;
+  }
 }
 
 /// Creates a nicely underlined hyperlink
 /// @param {Color} $link-color [$color-blue] Link color
 /// @param {Color} $link-color-active [$color-blue + 30] Link color for hover, active and focus states
 /// @param {Color} $background-color [#fff] Background color of the link, usually the same color as the page
+/// @param {Color} $background-color-active [#fff] Background color for hover, active and focus states
+/// @param {String} $underline-style [solid] The underline style can be solid or dashed
 /// @param {Boolean} $breaking-underlines [true] If the underline should "break" as it passes thru a descender
-@mixin fancy-link(
+@mixin underlined-link(
   $link-color: $color-blue,
   $link-color-active: $color-blue + 30,
   $background-color: #fff,
+  $background-color-active: #fff,
+  $underline-style: solid,
   $breaking-underlines: true
 ) {
-  @include underline(rgba($link-color, .4));
+  $transition: .2s ease;
+
+  @include underline(
+    $color: rgba($link-color, .4),
+    $background-color: $background-color,
+    $style: $underline-style
+  );
+
   color: $link-color;
   position: relative;
   text-decoration: none;
-  transition: color .2s ease;
+
+  @if $background-color-active != $background-color {
+    transition: background-color $transition, color $transition, text-shadow $transition;
+  } @else {
+    transition: color $transition;
+  }
+
   @if $breaking-underlines {
     text-shadow: -.1rem -.1rem 0 $background-color,
       .1rem -.1rem 0 $background-color,
@@ -94,17 +131,52 @@
   }
 
   @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-    @include underline($link-color, .05);
+    @include underline(
+      $color: $link-color,
+      $background-color: $background-color,
+      $weight: .05,
+      $style: $underline-style
+    );
   }
 
   &:hover,
   &:active,
-  &:focus {
-    @include underline(rgba($link-color-active, .4));
+  &:focus,
+  &.is-active {
     color: $link-color-active;
 
+    @if $underline-style == solid {
+      @include underline(
+        $color: rgba($link-color-active, .4)
+      );
+    }
+
+    @if $underline-style == dashed or $underline-style == dotted {
+      background-image: none;
+    }
+
+    @if $background-color-active != $background-color {
+      background-color: $background-color-active;
+    }
+
+    @if $breaking-underlines && $background-color-active != $background-color {
+      text-shadow: -.1rem -.1rem 0 $background-color-active,
+        .1rem -.1rem 0 $background-color-active,
+        -.1rem .1rem 0 $background-color-active,
+        .1rem .1rem 0 $background-color-active;
+    }
+
     @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-      @include underline($link-color-active, .05);
+      @if $underline-style == solid {
+        @include underline(
+          $color: $link-color-active,
+          $weight: .05
+        );
+      }
+
+      @if $underline-style == dashed or $underline-style == dotted {
+        background-image: none;
+      }
     }
   }
 }

--- a/sass/typography/_typography.scss
+++ b/sass/typography/_typography.scss
@@ -1,5 +1,5 @@
 %lede {
-  color: #2b3542;
+  color: $dark-blue;
   font-size: 1.8rem;
   font-weight: 300;
   line-height: 1.8;

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -37,7 +37,7 @@
 
     p:not(.copy--feature),
     .copy--body__list {
-      color: #2b3542;
+      color: $dark-blue;
       font-family: "Secondary";
       font-size: 1.8rem;
       line-height: (25 / 18);
@@ -68,10 +68,13 @@
       }
     }
 
-    li > a,
-    p:not(.stack__article__image-container) > a,
-    p:not(.copy--caption) > a {
-      @include fancy-link($link-color: #2b3542, $link-color-active: $color-blue);
+    li > a:not([data-poi-slug]),
+    p:not(.stack__article__image-container) > a:not([data-poi-slug]),
+    p:not(.copy--caption) > a:not([data-poi-slug]) {
+      @include underlined-link(
+        $link-color: $dark-blue,
+        $link-color-active: $color-blue
+      );
     }
 
     .stack__article__image-container {
@@ -159,6 +162,23 @@
     p.copy--caption {
       margin-bottom: 0;
       margin-top: 1.6rem;
+    }
+  }
+
+  a[data-poi-slug] {
+    @include underlined-link(
+      $link-color: $dark-blue,
+      $link-color-active: $color-blue
+    );
+
+    @media(min-width: $min-1200) {
+      @include underlined-link(
+        $link-color: $dark-blue,
+        $link-color-active: $dark-blue,
+        $background-color: #fff,
+        $background-color-active: #f0f0f0,
+        $underline-style: dashed
+      );
     }
   }
 }

--- a/src/components/article_body/index.js
+++ b/src/components/article_body/index.js
@@ -1,8 +1,10 @@
 import { Component } from "../../core/bane";
 import $ from "jquery";
 import ImageGallery from "../image_gallery";
+import PoiCallout from "../poi_callout";
 import moment from "moment";
-import "./article_body.scss";
+
+require("./article_body.scss");
 
 /**
  * Enhances the body of articles with a gallery and more
@@ -13,6 +15,7 @@ export default class ArticleBodyComponent extends Component {
 
     this.loadImages().then(() => {
       this.gallery = new ImageGallery({ el: ".article" });
+      this.pois = new PoiCallout({ el: this.$el });
     });
 
     this.formatDate();

--- a/src/components/article_body/index.js
+++ b/src/components/article_body/index.js
@@ -3,6 +3,7 @@ import $ from "jquery";
 import ImageGallery from "../image_gallery";
 import PoiCallout from "../poi_callout";
 import moment from "moment";
+import matchMedia from "../../core/utils/matchMedia";
 
 require("./article_body.scss");
 
@@ -15,7 +16,16 @@ export default class ArticleBodyComponent extends Component {
 
     this.loadImages().then(() => {
       this.gallery = new ImageGallery({ el: ".article" });
-      this.pois = new PoiCallout({ el: this.$el });
+    });
+
+    matchMedia("(min-width: 1200px)", (query) => {
+      if (query.matches) {
+        this.loadPoiCallout();
+      } else {
+        if (typeof this.poiCallout !== "undefined") {
+          this.poiCallout.destroy();
+        }
+      }
     });
 
     this.formatDate();
@@ -89,5 +99,45 @@ export default class ArticleBodyComponent extends Component {
     $footer
       .find("time").html(formattedDate)
       .closest(".js-article-post-date").removeProp("hidden");
+  }
+
+  /**
+   * Load POI data via AJAX
+   * @return {Promise} A promise for when the AJAX request finishes
+   */
+  loadPoiData() {
+    return new Promise((resolve, reject) => {
+      $.ajax(window.location.pathname, {
+        success: (response) => {
+          resolve(response.article.content.pois);
+        },
+        error: (xhrObj, textStatus, error) => {
+          reject(Error(error));
+        }
+      });
+    });
+  }
+
+  /**
+   * Creates a new instance of the POI callout; checks to see if the data
+   * already exists and if not, caches it in a variable.
+   * @return {[type]} [description]
+   */
+  loadPoiCallout() {
+    if (typeof this.poiData === "undefined") {
+      this.loadPoiData().then((response) => {
+        this.poiCallout = new PoiCallout({
+          el: this.$el,
+          pois: response
+        });
+
+        this.poiData = response;
+      });
+    } else {
+      this.poiCallout = new PoiCallout({
+        el: this.$el,
+        pois: this.poiData
+      });
+    }
   }
 }

--- a/src/components/poi_callout/index.js
+++ b/src/components/poi_callout/index.js
@@ -1,0 +1,4 @@
+import PoiCallout from "./poi_callout";
+require("./poi_callout.scss");
+
+export default PoiCallout;

--- a/src/components/poi_callout/poi_callout.hbs
+++ b/src/components/poi_callout/poi_callout.hbs
@@ -1,0 +1,8 @@
+<a class="poi-callout" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="poi-callout__content">
+    <img src="{{ image }}" alt="">
+    <h3>{{ name }}</h3>
+    <h5>{{ topic }}</h5>
+    <p>{{ excerpt }}</p>
+  </div>
+</a>

--- a/src/components/poi_callout/poi_callout.hbs
+++ b/src/components/poi_callout/poi_callout.hbs
@@ -1,8 +1,6 @@
-<a class="poi-callout" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="poi-callout__content">
-    <img src="{{ image }}" alt="">
-    <h3>{{ name }}</h3>
-    <h5>{{ topic }}</h5>
-    <p>{{ excerpt }}</p>
-  </div>
-</a>
+<div class="poi-callout__content">
+  <img src="{{ image }}" alt="">
+  <h3>{{ name }}</h3>
+  <h5>{{ topic }}</h5>
+  <p>{{ excerpt }}</p>
+</div>

--- a/src/components/poi_callout/poi_callout.js
+++ b/src/components/poi_callout/poi_callout.js
@@ -1,0 +1,227 @@
+import { Component } from "../../core/bane";
+import $ from "jquery";
+import $clamp from "clamp-js/clamp.js";
+import debounce from "lodash/function/debounce";
+
+export default class PoiCalloutComponent extends Component {
+  /**
+   * Render the POI callout
+   * @return {jQuery} Returns the poi-callout element
+   */
+  // get $poi() {
+  //   if (this._$poi) {
+  //     return this._$poi;
+  //   }
+
+  //   return this._$poi = $(this.template({})).appendTo("body");
+  // }
+
+  initialize(options, {
+    poiLinkSelector = "a[data-poi-slug]"
+  } = {}) {
+    this.template = require("./poi_callout.hbs");
+
+    this.$links = this.$el.find(poiLinkSelector);
+
+    this.poiLinkSelector = poiLinkSelector;
+
+    this.pois = options.pois;
+
+    this.events = {
+      ["mouseenter " + poiLinkSelector]: "_createPoiCallout",
+      ["mouseleave " + poiLinkSelector]: "_destroyPoiCallout"
+    };
+
+    // Append template
+    $(this.template({})).appendTo("body");
+
+    // Cache jQuery objects
+    this.$window = $(window);
+    this.$callout = $(".poi-callout");
+
+    // Set variables
+    this.calloutWidth = this.$callout.outerWidth();
+    this.left = this.$el.offset().left - this.calloutWidth - 35;
+    this.top = 0;
+    this.articleOffsetHeight = this.$el.height() + this.$el.offset().top;
+    this.mouseoutTimeout;
+    this.$activeLink;
+
+    this.$window.resize(debounce(() => {
+      this.left = (this.$window.width() >= 1370)
+        ? this.$el.offset().left - this.calloutWidth - 35
+        : this.$el.offset().left - this.calloutWidth;
+
+      this._windowEvents();
+    }, 10));
+
+    this.$window.scroll(debounce(() => {
+      this._windowEvents();
+    }, 10));
+
+    this.$callout.on("mouseenter", () => {
+      clearTimeout(this.mouseoutTimeout);
+    }).on("mouseleave", (event) => {
+      this._destroyPoiCallout(event);
+    });
+  }
+
+  /**
+   * Resets and detaches callout, removes all event handlers
+   */
+  destroy() {
+    this._resetPoiCallout();
+    this.$callout.detach();
+    this.$el.off("mouseenter mouseleave");
+    this.$callout.off("mouseenter mouseleave");
+    this.$window.off("resize scroll");
+  }
+
+  /**
+   * Creates the POI callout and positions it
+   * @param  {Object} event
+   * @return false
+   */
+  _createPoiCallout(event) {
+    event.preventDefault();
+
+    if (!this.$callout.hasClass("is-visible")) {
+      this.top = 0;
+      this.$callout.removeAttr("style");
+    }
+
+    this.$activeLink = $(event.currentTarget);
+
+    this.$activeLink
+      .addClass("is-active");
+
+    this._resetSiblingLinks();
+    this._setTopOffsetForPoiCallout();
+    this._updatePoiCallout();
+
+    clearTimeout(this.mouseoutTimeout);
+
+    return false;
+  }
+
+  /**
+   * Hides the POI callout
+   * @param  {Object} event
+   * @return false
+   */
+  _destroyPoiCallout(event) {
+    event.preventDefault();
+
+    this.mouseoutTimeout = setTimeout(() => {
+      this.$activeLink
+        .removeClass("is-active");
+
+      this.$callout
+        .attr("aria-hidden", "true")
+        .removeClass("is-visible");
+    }, 1000);
+
+    return false;
+  }
+
+  /**
+   * Removes the active class from sibling links
+   */
+  _resetSiblingLinks() {
+    // Remove the active class from siblings in the same paragraph
+    this.$activeLink
+      .siblings(this.poiLinkSelector)
+      .removeClass("is-active");
+
+    // Remove the active class from siblings in different paragraphs
+    this.$activeLink
+      .closest("p")
+      .siblings()
+      .find(this.poiLinkSelector)
+      .removeClass("is-active");
+  }
+
+  /**
+   * Updates the callout content, makes it visible and positions it
+   */
+  _updatePoiCallout() {
+    let poiData = this.pois[this.$activeLink.data("poiSlug")];
+    let image, src;
+
+    if (poiData.image) {
+      // TODO: Do this on the Ruby side
+      image = poiData.image.replace("http://media.lonelyplanet.com/", "");
+      src = `https://lonelyplanetimages.imgix.net/${image}?w=210&h=95&fit=crop`;
+    } else {
+      src = "";
+    }
+
+    this.$callout
+      .addClass("is-visible")
+      .attr({
+        "aria-hidden": "false",
+        "href": this.$activeLink.attr("href")
+      })
+      .css({
+        "top": `${this.top}px`,
+        "left": `${this.left}px`
+      })
+      .find("h3").html(poiData.name).end()
+      .find("h5").html(poiData.topic).end()
+      .find("p").html(poiData.excerpt).end()
+      .find("img").attr("src", src);
+
+    $clamp(this.$callout.find("p").get(0), { clamp: 3 });
+  }
+
+  /**
+   * Returns the callout to its "default" state
+   */
+  _resetPoiCallout() {
+    this.top = 0;
+
+    this.$callout
+      .attr("aria-hidden", "true")
+      .removeClass("is-visible")
+      .removeAttr("style");
+  }
+
+  /**
+   * Sets the top offset of the callout
+   */
+  _setTopOffsetForPoiCallout() {
+    let bottomOffset = this.$callout.height() + this.$activeLink.offset().top,
+        topOffset = this.$activeLink.offset().top,
+        calloutPosition = topOffset - this.$window.scrollTop() + this.$callout.outerHeight() + 30;
+
+    let isCalloutBelowBottom = this.articleOffsetHeight - bottomOffset < 0,
+        isCalloutOffscreen = calloutPosition > this.$window.height();
+
+    this.$window.scroll(debounce(() => {
+      calloutPosition = topOffset - this.$window.scrollTop() + this.$callout.outerHeight() + 30;
+    }, 100));
+
+    if (isCalloutBelowBottom) {
+      this.top = topOffset + (this.articleOffsetHeight - bottomOffset);
+
+    } else if (isCalloutOffscreen) {
+      this.top = topOffset - (calloutPosition - this.$window.height());
+
+    } else {
+      this.top = topOffset;
+
+    }
+  }
+
+  /**
+   * Methods for window events, such as resize and scroll
+   */
+  _windowEvents() {
+    if (typeof this.$activeLink !== "undefined") {
+      this.$activeLink
+        .removeClass("is-active");
+
+      this._resetPoiCallout();
+    }
+  }
+}

--- a/src/components/poi_callout/poi_callout.scss
+++ b/src/components/poi_callout/poi_callout.scss
@@ -1,0 +1,69 @@
+@import "../../../sass/webpack_deps";
+
+.poi-callout {
+  background-color: #fff;
+  box-shadow: .15rem .26rem 2.9rem rgba(#000, .08);
+  color: $dark-blue;
+  display: block;
+  max-height: 30rem;
+  max-width: 25rem;
+  opacity: 0;
+  padding: 2rem;
+  position: absolute;
+  transition: 1s ease;
+  visibility: hidden;
+  width: 25rem;
+  z-index: 1000;
+
+  .no-js & {
+    display: none;
+  }
+
+  &:hover,
+  &:active,
+  &:focus {
+    .poi-callout__content h3 {
+      color: $color-blue;
+    }
+  }
+
+  &.is-visible {
+    opacity: 1;
+    transform: translate3d(-15px, 0, 0);
+    transition: 0.2s ease 0.15s;
+    visibility: visible;
+  }
+}
+
+.poi-callout__content p {
+  font-size: 1.4rem;
+  font-weight: 300;
+  height: 7rem;
+  line-height: (22 / 14);
+  overflow: hidden;
+  margin-bottom: 0;
+  margin-top: 1.6rem;
+}
+
+.poi-callout__content img {
+  margin-bottom: 1.8rem;
+}
+
+.poi-callout__content h3 {
+  color: #29313e;
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: (20 / 16);
+  transition: color 200ms ease;
+}
+
+.poi-callout__content h5 {
+  color: #6d6d6d;
+  font-family: "Secondary", serif;
+  font-size: 1.6rem;
+  font-style: italic;
+  font-weight: 300;
+  line-height: 1;
+  margin-top: .5rem;
+  text-transform: capitalize;
+}


### PR DESCRIPTION
The POI callout component is currently only used in articles. Articles that mention (and link to) a POI on-site will use this component to show more information about the POI in a tooltip-like menu when the link is hovered.

The article body component has been updated as well in order to accommodate the POI callout. POI data is loaded via AJAX in the article body component, cached and then passed to the POI callout component. A promise is used to make sure the data is ready. Lastly, matchMedia is used to conditional initialize or destroy the POI callout inside of the article body.