### PR TITLE
Make travel alert links black w/underline

### DIFF
--- a/src/components/travel_alert/travel_alert.scss
+++ b/src/components/travel_alert/travel_alert.scss
@@ -10,6 +10,11 @@
   &__content {
     max-width: $max-width;
     margin: 0 auto;
+
+    a {
+      text-decoration: underline;
+      color: #333;
+    }
   }
 
   &--narrow {


### PR DESCRIPTION
![screen shot 2015-12-04 at 10 25 38 am](https://cloud.githubusercontent.com/assets/3247835/11594762/6a708e8a-9a71-11e5-9b36-eccbec730971.png)
