### PR TITLE
Remove Tabs component from articles; Add standard heading

### DIFF
--- a/src/components/articles/articles.hbs
+++ b/src/components/articles/articles.hbs
@@ -1,84 +1,75 @@
 <article class="articles">
-  <div class="tabs">
-    <ul class="tabs__links">
-      <li><a href="#articles-top">{{articles_title}}</a></li>
-      {{#if top_news_articles.cards}}
-      {{! Uncomment when the news stuff is ready}}
-      {{! <li><a href="#articles-news">news_title/a></li> }}
-      {{/if}}
-    </ul>
-    <div class="tabs__content" id="articles-top">
-      <div class="articles__list">
-      {{#each articles}}
-        <article class="article">
-          <div class="article__info">
-            <a class="article__info__link" href="{{url}}">
-              <h2 class="article__info__title">{{title}}</h2>
-              <p class="article__info__teaser">{{teaser1}}</p>
-              <p class="article__info__blurb">{{teaser2}}</p>
-            </a>
+  <div id="articles-top">
+    <h2 class="articles__heading">{{articles_title}}</h2>
+    <div class="articles__list">
+    {{#each articles}}
+      <article class="article">
+        <div class="article__info">
+          <a class="article__info__link" href="{{url}}">
+            <h2 class="article__info__title">{{title}}</h2>
+            <p class="article__info__teaser">{{teaser1}}</p>
+            <p class="article__info__blurb">{{teaser2}}</p>
+          </a>
 
-            <a class="article__info__author" href="{{author_url}}">
-              {{#if author_image}}
-                <img class="article__info__author__image" src="{{author_image}}">
-              {{/if}}
-              <div class="article__info__author__creds">
-                <div class="article__info__author__creds__name">{{author_name}}</div>
-                <div class="article__info__author__creds__title">{{author_title}}</div>
-              </div>
-            </a>
-          </div>
-          {{#if src}}
-            <a class="article__imagery" href="{{url}}" tabindex="-1">
-              <div class="article__imagery__image" aria-label="Image for {{title}}" style="background-image: url({{src}})"></div>
-            </a>
-          {{/if}}
-        </article>
-      {{/each}}
-      </div>
+          <a class="article__info__author" href="{{author_url}}">
+            {{#if author_image}}
+              <img class="article__info__author__image" src="{{author_image}}">
+            {{/if}}
+            <div class="article__info__author__creds">
+              <div class="article__info__author__creds__name">{{author_name}}</div>
+              <div class="article__info__author__creds__title">{{author_title}}</div>
+            </div>
+          </a>
+        </div>
+        {{#if src}}
+          <a class="article__imagery" href="{{url}}" tabindex="-1">
+            <div class="article__imagery__image" aria-label="Image for {{title}}" style="background-image: url({{src}})"></div>
+          </a>
+        {{/if}}
+      </article>
+    {{/each}}
+    </div>
 
-      <div class="articles__button-container">
-        <a class="articles__more" href="{{see_more_url}}">
-          Read more articles
-          <span class="icon-chevron-right"></span>
-        </a>
-      </div>
-    </div> <!-- /tabs__content -->
+    <div class="articles__button-container">
+      <a class="articles__more" href="{{see_more_url}}">
+        Read more articles
+        <span class="icon-chevron-right"></span>
+      </a>
+    </div>
+  </div> <!-- /tabs__content -->
 
-    {{#if top_news_articles.cards}}
-    <div class="tabs__content" id="articles-news">
-      <div class="articles__list">
-      {{#each top_news_articles.cards}}
-        <article class="article">
-          <div class="article__info">
-            <a href="http://www.lonelyplanet.com/{{slug}}">
-              <h2 class="article__info__title">{{title}}</h2>
-              <p class="article__info__blurb">{{description}}</p>
-            </a>
+  {{#if top_news_articles.cards}}
+  <div class="tabs__content" id="articles-news">
+    <div class="articles__list">
+    {{#each top_news_articles.cards}}
+      <article class="article">
+        <div class="article__info">
+          <a href="http://www.lonelyplanet.com/{{slug}}">
+            <h2 class="article__info__title">{{title}}</h2>
+            <p class="article__info__blurb">{{description}}</p>
+          </a>
 
-            <a class="article__info__author" href="{{author_url}}">
-              <div class="article__info__author__creds">
-                <div class="article__info__author__creds__name">{{author}}</div>
-                <div class="article__info__author__creds__title">{{date}}</div>
-              </div>
-            </a>
-          </div>
-          {{#if image_url}}
-            <a href="{{slug}}">
-              <div class="article__imagery" style="background-image: url({{image_url}})"></div>
-            </a>
-          {{/if}}
-        </article>
-      {{/each}}
-      </div>
+          <a class="article__info__author" href="{{author_url}}">
+            <div class="article__info__author__creds">
+              <div class="article__info__author__creds__name">{{author}}</div>
+              <div class="article__info__author__creds__title">{{date}}</div>
+            </div>
+          </a>
+        </div>
+        {{#if image_url}}
+          <a href="{{slug}}">
+            <div class="article__imagery" style="background-image: url({{image_url}})"></div>
+          </a>
+        {{/if}}
+      </article>
+    {{/each}}
+    </div>
 
-      <div class="articles__button-container">
-        <a class="articles__more" href="{{see_more_news}}">
-          Read more articles
-          <span class="icon-chevron-right"></span>
-        </a>
-      </div>
-    </div> <!-- /tabs__content -->
-  </div>
+    <div class="articles__button-container">
+      <a class="articles__more" href="{{see_more_news}}">
+        Read more articles
+        <span class="icon-chevron-right"></span>
+      </a>
+    </div>
   {{/if}}
 </article>

--- a/src/components/articles/index.js
+++ b/src/components/articles/index.js
@@ -1,6 +1,5 @@
 import { Component } from "../../core/bane";
 import $clamp from "clamp-js/clamp.js";
-import Tabs from "../tabs/tabs_component";
 import $ from "jquery";
 
 import "./_articles.scss";
@@ -14,15 +13,11 @@ class ArticlesComponent extends Component {
     this.blurbLineHeight = options.blurbLineHeight || { desktop: 27, mobile: 18 };
     this.mobileWidth = options.mobileWidth || 717;
     this.screen = "mobile";
-    this.tabs = new Tabs({
-      el: $(".articles").find(".tabs")
-    });
 
     if (!$("html").hasClass("ie9")) {
       this._detectScreen();
       this._clampText();
 
-      this.listenTo(this.tabs, "tabs.activate", this._reclamp.bind(this));
       $(window).on("resize", this._reclamp.bind(this));
     }
   }


### PR DESCRIPTION
With the removal of news articles for the time being, it was decided to remove the tabs altogether and have the articles component display the same title design as other components.

Before:
![screen shot 2015-12-04 at 12 19 50 pm](https://cloud.githubusercontent.com/assets/3247835/11597455/644f2d62-9a81-11e5-8e96-51460bc9e9ee.png)

After:
![screen shot 2015-12-04 at 12 19 39 pm](https://cloud.githubusercontent.com/assets/3247835/11597464/6d16129e-9a81-11e5-8058-d717281d121e.png)

