### PR TITLE
Tweak 'see more' icon height; Change "tours" to "adventures

### DIFF
--- a/sass/typography/_links_mixins.scss
+++ b/sass/typography/_links_mixins.scss
@@ -35,6 +35,7 @@
 
     font-size: 6px;
     vertical-align: 20%;
+    line-height: 1.6;
 
     transition: transform 500ms;
 

--- a/src/components/interests/_interests.scss
+++ b/src/components/interests/_interests.scss
@@ -100,17 +100,11 @@ $max-card-width: 1395px;
           @if $parity == "odd" {
             .interests__card__link {
               text-transform: capitalize;
-              //text-align: left;
-              //font-size: 40px;
-
               left: $gutter;
               bottom: $gutter;
               right: $gutter;
-
-              padding-top: 1.8rem;
-
               font-size: 3.6rem;
-              line-height: 1;
+              line-height: 1.5;
               text-align: left;
             }
           }
@@ -179,13 +173,13 @@ $max-card-width: 1395px;
   margin: 0 auto;
 
   overflow: hidden;
-  
+
   &--9 {
     @media (min-width: $max-card-width) {
       margin-left: -1.5rem;
-    }  
+    }
   }
-  
+
 
   .interests__card {
     float: left;
@@ -218,7 +212,7 @@ $max-card-width: 1395px;
         right: 0;
         bottom: 0;
 
-        background: linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 32%); 
+        background: linear-gradient(to top, rgba(0, 0, 0, 0.4) 0%, transparent 32%);
       }
 
       .interests__card__bottom {
@@ -238,7 +232,7 @@ $max-card-width: 1395px;
         width: 90%;
         margin: 0 auto;
       }
-  
+
       .interests__card__link {
         display: table-cell;
         vertical-align: middle;

--- a/src/components/tours/tours.hbs
+++ b/src/components/tours/tours.hbs
@@ -26,7 +26,7 @@
 
     <div class="tours__button-container">
       <a class="tours__more" href="{{see_more_url}}">
-        See More Tours
+        See More Adventures
         <span class="icon-chevron-right"></span>
       </a>
     </div>


### PR DESCRIPTION
Changing the 'branding' of the tours component to "adventures" is an attempt to boost user interaction. Also threw in a tweak to the right arrow on "see more" links to better center them vertically