### PR TITLE
"Search _____ and beyond" comes from `search.title`

### DIFF
--- a/src/components/header/header.hbs
+++ b/src/components/header/header.hbs
@@ -15,7 +15,7 @@
 
       <button class="header__search js-search">
         <i class="icon-search" aria-hidden="true"></i>
-        <span class="header__search-text">Search {{place.title}}</span>
+        <span class="header__search-text">Search {{search.title}}</span>
         <span class="header__search-beyond">and beyond</span>
       </button>
 


### PR DESCRIPTION
Now that DN serves more than just place pages, the title used in the search bar should be derived from a variable that is agnostic to the type of page being rendered.