### PR TITLE
New Sights component for highlights pages

### DIFF
--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -10,7 +10,6 @@ import moment from "moment";
 
 
 let userPanelTemplate = require("./user_panel.hbs");
-// Handlebars.registerPartial('submenu', $("#submenu").html());
 
 class NavigationComponent extends Component {
 

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -1,92 +1,147 @@
 @import "../../../sass/webpack_deps";
-$item-width: 41rem;
-$image-width: 8rem;
-$order-width: 6rem;
+$image-width: 5.5rem;
+$order-width: 4.5rem;
 $toggle-width: 10vw;
 
 .sights {
-  margin-left: 2.5rem;
+  @include container-static(12);
+  padding: 0 1rem;
+  counter-reset: sight-count;
 
-  &__list {
+  &__title {
+    text-align: center;
+    padding-bottom: 1rem;
 
+    @media (min-width: $min-600) {
+      text-align: left;
+    }
+  }
+
+  &__list, &__title {
+    margin: 0 auto;
+
+    @media (min-width: $min-720) {
+      width: 90%;
+    }
+
+    @media (min-width: $min-840) {
+      width: 80%;
+    }
+
+    @media (min-width: $min-960) {
+      width: 100%;
+    }
+  }
+
+  &__column {
+    @media (min-width: $min-600) {
+      @include gallery(6 of 12);
+    }
+
+    @media (min-width: $min-960) {
+      @include gallery(4 of 12);
+    }
+
+    .sights__item:first-child:before {
+      content: "";
+      position: absolute;
+      top: -.3rem;
+      left: 0;
+      display: block;
+      height: 0;
+      width: 100%;
+      border-top: .1rem solid $divider-color;
+    }
+  }
+
+  &__column--3 {
+    display: none;
+
+    @media (min-width: $min-960) {
+      display: inline-block;
+    }
   }
 
   &__item {
-    height: 6rem;
-    display: inline-block;
+    height: 5rem;
     position: relative;
     cursor: pointer;
-    width: $item-width;
-    margin-top: ($gutter / 3);
-    margin-bottom: ($gutter / 3);
+    margin-top: .5rem;
 
-    &:before,
     &:after {
       position: absolute;
       display: block;
       height: 0;
-      width: $item-width;
+      width: 100%;
       border-top: .1rem solid $divider-color;
       content: "";
-    }
-
-    &:after {
-      bottom: 0;
-      left: 0;
-    }
-
-    &:before {
-      top: 0;
+      bottom: -.3rem;
       left: 0;
     }
 
     &__img {
       background-size: cover;
       background-repeat: no-repeat;
-      height: 100%;
-      width: 8rem;
+      height: 4rem;
+      width: $image-width;
       overflow: hidden;
       position: absolute;
-      top: 0;
+      top: calc(50% - 2rem);
       left: 0;
+
+      &:before {
+        width: $image-width;
+        background-position: center -63px;
+      }
     }
 
     &__text {
       position: absolute;
       top: 50%;
       transform: translate(0, -50%);
-      width: ($item-width - $image-width - $gutter);
-      padding-right: 1rem;
-      left: 10.7rem;
+      left: $image-width + 2rem;
+      width: calc(100% - #{$image-width} - #{$order-width});
 
       .title {
-        font-size: 1.6rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 1.2rem;
+        font-weight: 600;
         color: $color-darkblue;
         transition: color $animation-speed ease;
       }
+
+      .subtitle {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: $footer-bottom-link-color;
+        font-size: .9rem;
+        font-weight: 600;
+        text-transform: uppercase;
+      }
     }
 
-    &.is-hovered {
+    &:hover {
       .title {
         color: $color-blue;
       }
     }
-
 
     &__order {
       position: absolute;
       width: $order-width;
       height: $order-width;
       display: block;
-      left: $image-width;
+      left: $image-width - .1rem;
       top: 50%;
       transform: translate(-50%, -50%);
       text-align: center;
       line-height: $order-width;
       font-weight: bold;
       color: $feature-copy;
-      font-size: 1.2rem;
-      padding-top: .2rem;
+      font-size: 1rem;
 
       &:before {
         position: absolute;
@@ -102,6 +157,11 @@ $toggle-width: 10vw;
         box-shadow: .2rem .1rem .4rem -.2rem #333;
         border-radius: .4rem;
       }
-    }`
+
+      &:after {
+        counter-increment: sight-count;
+        content: counter(sight-count);
+      }
+    }
   }
 }

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -8,13 +8,17 @@ $toggle-width: 10vw;
   padding: 0 1rem;
   counter-reset: sight-count;
 
-  &__title {
+  &__heading--small {
     text-align: center;
     padding-bottom: 1rem;
 
     @media (min-width: $min-600) {
       text-align: left;
     }
+  }
+
+  &__heading--large {
+    @include h1();
   }
 
   &__list, &__title {

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -21,7 +21,7 @@ $toggle-width: 10vw;
     @include h1();
   }
 
-  &__list, &__title {
+  &__list, &__heading--small {
     margin: 0 auto;
 
     @media (min-width: $min-720) {

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -1,0 +1,107 @@
+@import "../../../sass/webpack_deps";
+$item-width: 41rem;
+$image-width: 8rem;
+$order-width: 6rem;
+$toggle-width: 10vw;
+
+.sights {
+  margin-left: 2.5rem;
+
+  &__list {
+
+  }
+
+  &__item {
+    height: 6rem;
+    display: inline-block;
+    position: relative;
+    cursor: pointer;
+    width: $item-width;
+    margin-top: ($gutter / 3);
+    margin-bottom: ($gutter / 3);
+
+    &:before,
+    &:after {
+      position: absolute;
+      display: block;
+      height: 0;
+      width: $item-width;
+      border-top: .1rem solid $divider-color;
+      content: "";
+    }
+
+    &:after {
+      bottom: 0;
+      left: 0;
+    }
+
+    &:before {
+      top: 0;
+      left: 0;
+    }
+
+    &__img {
+      background-size: cover;
+      background-repeat: no-repeat;
+      height: 100%;
+      width: 8rem;
+      overflow: hidden;
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
+
+    &__text {
+      position: absolute;
+      top: 50%;
+      transform: translate(0, -50%);
+      width: ($item-width - $image-width - $gutter);
+      padding-right: 1rem;
+      left: 10.7rem;
+
+      .title {
+        font-size: 1.6rem;
+        color: $color-darkblue;
+        transition: color $animation-speed ease;
+      }
+    }
+
+    &.is-hovered {
+      .title {
+        color: $color-blue;
+      }
+    }
+
+
+    &__order {
+      position: absolute;
+      width: $order-width;
+      height: $order-width;
+      display: block;
+      left: $image-width;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      text-align: center;
+      line-height: $order-width;
+      font-weight: bold;
+      color: $feature-copy;
+      font-size: 1.2rem;
+      padding-top: .2rem;
+
+      &:before {
+        position: absolute;
+        display: block;
+        background-color: #fff;
+        top: 50%;
+        left: 50%;
+        width: 40%;
+        height: 40%;
+        transform: translate(-50%, -50%) rotate(45deg);
+        content: "";
+        z-index: -1;
+        box-shadow: .2rem .1rem .4rem -.2rem #333;
+        border-radius: .4rem;
+      }
+    }`
+  }
+}

--- a/src/components/sights/index.js
+++ b/src/components/sights/index.js
@@ -1,0 +1,1 @@
+import "./_sights.scss";

--- a/src/components/sights/index.js
+++ b/src/components/sights/index.js
@@ -1,1 +1,5 @@
-import "./_sights.scss";
+import Sights from "./sights_component";
+
+require("./_sights.scss");
+
+export default Sights;

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,5 +1,6 @@
 <article class="sights">
-  <h3 class=sights__title>{{sights_title}}</h3>
+  <h3 class="sights__heading sights__heading--small">{{sights_title}}</h3>
+  <h2 class="sights__heading sights__heading--large is-hidden">{{sights_title}}</h2>
   <div class="sights__list">
   {{#if show}}
     <div class="sights__column sights__column--1">

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -6,16 +6,16 @@
     <div class="sights__column sights__column--1">
     {{#each first_column}}
       <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{this.slug}}">
-          {{#if this.hero_image_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+        <a href="http://www.lonelyplanet.com/{{slug}}">
+          {{#if img_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
             {{else}}
             <div class="sights__item__img topic__image--sight"></div>
           {{/if}}
           <div class="sights__item__order"></div>
           <div class="sights__item__text">
-            <div class="title">{{this.name}}</div>
-            <div class="subtitle">HONG KONG ISLAND</div>
+            <div class="title">{{title}}</div>
+            <div class="subtitle">{{subtitle}}</div>
           </div>
         </a>
       </div>
@@ -24,16 +24,16 @@
     <div class="sights__column sights__column--2">
     {{#each second_column}}
       <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{this.slug}}">
-          {{#if this.hero_image_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+        <a href="http://www.lonelyplanet.com/{{slug}}">
+          {{#if img_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
             {{else}}
             <div class="sights__item__img topic__image--sight"></div>
           {{/if}}
           <div class="sights__item__order"></div>
           <div class="sights__item__text">
-            <div class="title">{{this.name}}</div>
-            <div class="subtitle">HONG KONG ISLAND</div>
+            <div class="title">{{title}}</div>
+            <div class="subtitle">{{subtitle}}</div>
           </div>
         </a>
       </div>
@@ -43,16 +43,16 @@
     <div class="sights__column sights__column--3">
       {{#each third_column}}
       <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{this.slug}}">
-          {{#if this.hero_image_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+        <a href="http://www.lonelyplanet.com/{{slug}}">
+          {{#if img_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
             {{else}}
             <div class="sights__item__img topic__image--sight"></div>
           {{/if}}
           <div class="sights__item__order"></div>
           <div class="sights__item__text">
-            <div class="title">{{this.name}}</div>
-            <div class="subtitle">HONG KONG ISLAND</div>
+            <div class="title">{{title}}</div>
+            <div class="subtitle">{{subtitle}}</div>
           </div>
         </a>
       </div>

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,16 +1,57 @@
 <article class="sights">
-  <h2 class=sights__title>{{sights_title}}</h2>
-  <ul class="sights__list">
-    {{#each sights}}
-      <li class="sights__item">
-        <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
-        <div class="sights__item__order">{{@index}}</div>
+  <h3 class=sights__title>{{sights_title}}</h3>
+  <div class="sights__list">
+  {{#if show}}
+    <div class="sights__column sights__column--1">
+    {{#each first_column}}
+      <div class="sights__item">
+        {{#if this.hero_image_url}}
+          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+          {{else}}
+          <div class="sights__item__img topic__image--sight"></div>
+        {{/if}}
+        <div class="sights__item__order"></div>
         <div class="sights__item__text">
           <div class="title">{{this.name}}</div>
-          <div class="subtitle">{{subtitle}}</div>
+          <div class="subtitle">HONG KONG ISLAND</div>
         </div>
-      </li>
+      </div>
     {{/each}}
-  </ul>
-
+    </div>
+    <div class="sights__column sights__column--2">
+    {{#each second_column}}
+      <div class="sights__item">
+        {{#if this.hero_image_url}}
+          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+          {{else}}
+          <div class="sights__item__img topic__image--sight"></div>
+        {{/if}}
+        <div class="sights__item__order"></div>
+        <div class="sights__item__text">
+          <div class="title">{{this.name}}</div>
+          <div class="subtitle">HONG KONG ISLAND</div>
+        </div>
+      </div>
+    {{/each}}
+    </div>
+    {{#if third_column}}
+    <div class="sights__column sights__column--3">
+      {{#each third_column}}
+      <div class="sights__item">
+        {{#if this.hero_image_url}}
+          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+          {{else}}
+          <div class="sights__item__img topic__image--sight"></div>
+        {{/if}}
+        <div class="sights__item__order"></div>
+        <div class="sights__item__text">
+          <div class="title">{{this.name}}</div>
+          <div class="subtitle">HONG KONG ISLAND</div>
+        </div>
+      </div>
+      {{/each}}
+    </div>
+    {{/if}}
+  {{/if}}
+  </div>
 </article>

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -6,32 +6,36 @@
     <div class="sights__column sights__column--1">
     {{#each first_column}}
       <div class="sights__item">
-        {{#if this.hero_image_url}}
-          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
-          {{else}}
-          <div class="sights__item__img topic__image--sight"></div>
-        {{/if}}
-        <div class="sights__item__order"></div>
-        <div class="sights__item__text">
-          <div class="title">{{this.name}}</div>
-          <div class="subtitle">HONG KONG ISLAND</div>
-        </div>
+        <a href="http://www.lonelyplanet.com/{{this.slug}}">
+          {{#if this.hero_image_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+            {{else}}
+            <div class="sights__item__img topic__image--sight"></div>
+          {{/if}}
+          <div class="sights__item__order"></div>
+          <div class="sights__item__text">
+            <div class="title">{{this.name}}</div>
+            <div class="subtitle">HONG KONG ISLAND</div>
+          </div>
+        </a>
       </div>
     {{/each}}
     </div>
     <div class="sights__column sights__column--2">
     {{#each second_column}}
       <div class="sights__item">
-        {{#if this.hero_image_url}}
-          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
-          {{else}}
-          <div class="sights__item__img topic__image--sight"></div>
-        {{/if}}
-        <div class="sights__item__order"></div>
-        <div class="sights__item__text">
-          <div class="title">{{this.name}}</div>
-          <div class="subtitle">HONG KONG ISLAND</div>
-        </div>
+        <a href="http://www.lonelyplanet.com/{{this.slug}}">
+          {{#if this.hero_image_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+            {{else}}
+            <div class="sights__item__img topic__image--sight"></div>
+          {{/if}}
+          <div class="sights__item__order"></div>
+          <div class="sights__item__text">
+            <div class="title">{{this.name}}</div>
+            <div class="subtitle">HONG KONG ISLAND</div>
+          </div>
+        </a>
       </div>
     {{/each}}
     </div>
@@ -39,16 +43,18 @@
     <div class="sights__column sights__column--3">
       {{#each third_column}}
       <div class="sights__item">
-        {{#if this.hero_image_url}}
-          <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
-          {{else}}
-          <div class="sights__item__img topic__image--sight"></div>
-        {{/if}}
-        <div class="sights__item__order"></div>
-        <div class="sights__item__text">
-          <div class="title">{{this.name}}</div>
-          <div class="subtitle">HONG KONG ISLAND</div>
-        </div>
+        <a href="http://www.lonelyplanet.com/{{this.slug}}">
+          {{#if this.hero_image_url}}
+            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+            {{else}}
+            <div class="sights__item__img topic__image--sight"></div>
+          {{/if}}
+          <div class="sights__item__order"></div>
+          <div class="sights__item__text">
+            <div class="title">{{this.name}}</div>
+            <div class="subtitle">HONG KONG ISLAND</div>
+          </div>
+        </a>
       </div>
       {{/each}}
     </div>

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,0 +1,16 @@
+<article class="sights">
+  <h2 class=sights__title>{{sights_title}}</h2>
+  <ul class="sights__list">
+    {{#each sights}}
+      <li class="sights__item">
+        <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{this.hero_image_url}}')"></div>
+        <div class="sights__item__order">{{@index}}</div>
+        <div class="sights__item__text">
+          <div class="title">{{this.name}}</div>
+          <div class="subtitle">{{subtitle}}</div>
+        </div>
+      </li>
+    {{/each}}
+  </ul>
+
+</article>

--- a/src/components/sights/sights_component.js
+++ b/src/components/sights/sights_component.js
@@ -1,0 +1,12 @@
+import Component from "../../core/component";
+import subscribe from "../../core/decorators/subscribe";
+
+export default class Sights extends Component {
+  initialize() {
+    this.subscribe();
+  }
+  @subscribe("ttd.removed", "components")
+  _changeTitle() {
+    this.$el.find(".sights__heading").toggleClass("is-hidden");
+  }
+}

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -130,12 +130,20 @@ export default class SubNav extends Component {
     this.contentHeight = $(".navigation-wrapper").outerHeight();
   }
   /**
-   * If a component is removed from the DOM, this will remove it's subnav element
+   * If a component is removed from the DOM, this will remove its subnav element
    */
   @subscribe("*.removed", "components")
   removeSubNav(data, envelope) {
     let component = envelope.topic.split(".")[0];
 
     this.$el.find(`.sub-nav__item--${component}`).remove();
+  }
+  @subscribe("ttd.removed", "components")
+  addSights() {
+    $(
+    `<li class="sub-nav__item sub-nav__item--sights">
+      <a class="sub-nav__link js-sub-nav-link" href="#sights">sights</a>
+    </li>
+    `).prependTo(this.$el.find(".sub-nav__list"));
   }
 }

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -27,7 +27,7 @@
       }
     }
 
-    .has-more--right:before, .has-more--left:before {
+    &:before, &:after {
       content: "";
       display: block;
       height: 100%;
@@ -35,14 +35,19 @@
       top: 0%;
       background: #fff;
       z-index: 10;
-      width: 7%;
+      width: 4%;
+
 
       @media (min-width: $min-480) {
         width: 8%;
       }
+
+      @media (min-width: $min-1410) {
+        width: 25%;
+      }
     }
 
-    .has-more--left:before {
+    &:before {
       left: -2rem;
 
       @media (min-width: $min-480) {
@@ -52,9 +57,13 @@
       @media (min-width: $min-840) {
         left: -7%;
       }
+
+      @media (min-width: $min-1410) {
+        left: -25%;
+      }
     }
 
-    .has-more--right:before {
+    &:after {
       right: -2rem;
 
       @media (min-width: $min-480) {
@@ -63,6 +72,10 @@
 
       @media (min-width: $min-840) {
         right: -7%;
+      }
+
+      @media (min-width: $min-1410) {
+        right: -25%;
       }
     }
   }
@@ -132,8 +145,6 @@
     height: 6vw;
     min-width: 4rem;
     width: 6vw;
-    padding-left: 7px;
-    padding-top: 3px;
     top: calc(50% - (4vw + #{$gutter} / 8));
     z-index: 15;
     border-radius: 50%;
@@ -142,7 +153,7 @@
     background: #fff;
 
     @media (min-width: $min-480) {
-      top: calc(50% - 3vw);
+      top: calc(50% - 3.5vw);
     }
 
     @media (min-width: $min-960) {

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -128,13 +128,13 @@
   &__more, &__less {
     cursor: pointer;
     position: absolute;
-    min-height: 3rem;
+    min-height: 4rem;
     height: 6vw;
-    min-width: 3rem;
+    min-width: 4rem;
     width: 6vw;
     padding-left: 7px;
     padding-top: 3px;
-    top: calc(50% - (3vw + #{$gutter} / 8));
+    top: calc(50% - (4vw + #{$gutter} / 8));
     z-index: 15;
     border-radius: 50%;
     border: none;

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -3,8 +3,6 @@
 .ttd {
   overflow: hidden;
   position: relative;
-  // changed margin to padding to allow 'see more' shadow to extend
-  padding-bottom: $gutter;
 
   @media (min-width: $min-840) {
     overflow: hidden;

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -1,12 +1,8 @@
 @import "../../../sass/webpack_deps";
 
 .ttd {
-  overflow: hidden;
+  overflow: visible;
   position: relative;
-
-  @media (min-width: $min-840) {
-    overflow: hidden;
-  }
 
   &__heading {
     @include h1();
@@ -15,36 +11,10 @@
 
   &__list-container {
     position: relative;
-    
-    @media (min-width: $min-480) {
-      margin: 0 0 ($gutter * 2);
-    }
+    margin-bottom: $gutter;
 
-    .has-more--right:before, .has-more--left:before {
-      @media (min-width: $min-480) {
-        content: "";
-        display: block;
-        height: 150%;
-        position: absolute;
-        top: -25%;
-        background: #fff;
-        z-index: 10;
-        width: 12%;
-      }
-    }
-
-    .has-more--right:before {
-      @media (min-width: $min-480) {
-        right: -4rem;
-      }
-
-      @media (min-width: $min-840) {
-        right: 0;
-      }
-
-      @media (min-width: $min-960) {
-        width: 2.5rem;
-      }
+    @media (min-width: $min-960) {
+      margin-bottom: 2rem;
     }
 
     .has-more--left, .has-more--right {
@@ -56,86 +26,43 @@
         pointer-events: none;
       }
     }
-    
-    .has-more--right:after, .has-more--left:after {
+
+    .has-more--right:before, .has-more--left:before {
       content: "";
       display: block;
-      height: 120%;
-      width: 4rem;
-      margin-top: -16%;
-      border-radius: 50%;
+      height: 100%;
       position: absolute;
-      top: 0;
-    }
+      top: 0%;
+      background: #fff;
+      z-index: 10;
+      width: 7%;
 
-    .has-more--right:after {
-      box-shadow: -8px 0px 45px -2px rgba(0, 0, 0, 0.75);
-      right: -4rem;
-      
       @media (min-width: $min-480) {
-        height: 112%;
-        width: 12%;
-        right: -9.2%;
-        margin-top: -7.5%;
-      }
-
-      @media (min-width: $min-600) {
-        right: -6.8%;
-        box-shadow: -8px 0px 45px 8px rgba(0, 0, 0, 0.75);
-      }
-
-      @media (min-width: $min-840) {
-        width: 4.5rem;
-        right: 5rem;
-      }
-
-      @media (min-width: $min-960) {
-        height: 130%;
-        margin-top: -6.5%;
-        right: -3rem;
-        box-shadow: -8px 0px 40px -2px rgba(0, 0, 0, 0.75);
+        width: 8%;
       }
     }
 
     .has-more--left:before {
+      left: -2rem;
+
       @media (min-width: $min-480) {
-        left: -4rem;
+        left: -3rem;
       }
 
       @media (min-width: $min-840) {
-        left: 0;
-      }
-
-      @media (min-width: $min-960) {
-        width: 2.5rem;
+        left: -7%;
       }
     }
 
-    .has-more--left:after {
-      box-shadow: 8px 0px 45px 2px rgba(0, 0, 0, 0.75);
-      left: -4rem;
-      @media (min-width: $min-480) {
-        height: 112%;
-        width: 12%;
-        left: -9.2%;
-        margin-top: -7.5%;
-      }
+    .has-more--right:before {
+      right: -2rem;
 
-      @media (min-width: $min-600) {
-        left: -6.8%;
-        box-shadow: 8px 0px 45px 8px rgba(0, 0, 0, 0.75);
+      @media (min-width: $min-480) {
+        right: -3rem;
       }
 
       @media (min-width: $min-840) {
-        width: 4.5rem;
-        left: 5rem;
-      }
-
-      @media (min-width: $min-960) {
-        height: 130%;
-        margin-top: -6.5%;
-        left: -3rem;
-        box-shadow: 8px 0px 40px 2px rgba(0, 0, 0, 0.75);
+        right: -7%;
       }
     }
   }
@@ -143,7 +70,7 @@
   &__list {
     // Controls the speed of the more and less
     transition: 500ms transform ease-in-out;
-    margin: 0 (-$gutter/8) $gutter;
+    margin: 0 (-$gutter/8);
     list-style: none;
     font-size: 0;
     text-align: left;
@@ -154,8 +81,6 @@
     &--next {
       opacity: 0;
     }
-
-    
   }
 
   &__item {
@@ -192,10 +117,12 @@
 
   }
   &__more {
-    right: .8rem;
+    right: -0.5rem;
+    box-shadow: .2rem .1rem .4rem -.3rem #333;
   }
   &__less {
-    left: .8rem;
+    left: -0.5rem;
+    box-shadow: -.2rem .1rem .4rem -.3rem #333;
   }
 
   &__more, &__less {
@@ -213,7 +140,6 @@
     border: none;
     outline: none;
     background: #fff;
-    display: none;
 
     @media (min-width: $min-480) {
       top: calc(50% - 3vw);
@@ -227,7 +153,7 @@
     }
 
     &__icon {
-      font-size: 1.3rem;
+      font-size: 1rem;
     }
 
     &.is-invisible {
@@ -320,15 +246,6 @@
       display: block;
       transform: rotate(-45deg);
     }
-
-    // &:before {
-    //   display: block;
-
-    //   counter-increment: image-card;
-    //   content: counter(image-card);
-
-    //   transform: rotate(-45deg);
-    // }
 
     @media (min-width: $min-480) {
       $size: 3.7rem;

--- a/src/components/tours/_tours.scss
+++ b/src/components/tours/_tours.scss
@@ -198,6 +198,7 @@ $tours-width: 52rem / $tours-width-base * 100%;
 
 .tours__button-container {
   @include see-more-link;
+  margin-top: 0;
 }
 
 .tours__more {


### PR DESCRIPTION
This adds a sub-component of Things to Do that displays a list of sights under TTD,designed after the items list in the map sidebar. If no TTD is present, Sights takes its place in the subnav and its header/title is centered and styled like the other components. Displays 6 - 9 sights. If fewer than 6 sights are returned, component does not display.

This one is worth pulling down and playing with in various places to see/check how it responds. 
`/asia` and `/nashville` are good places to start.

Requires https://github.com/lonelyplanet/destinations-next/pull/567

with TTD:
![screen shot 2015-12-11 at 4 12 18 pm](https://cloud.githubusercontent.com/assets/3247835/11756796/217768be-a022-11e5-807f-8294050b07d9.png)
without TTD:
![screen shot 2015-12-11 at 4 12 43 pm](https://cloud.githubusercontent.com/assets/3247835/11756800/29dc850c-a022-11e5-92a1-afcfa55c929d.png)
