### PR TITLE
Remove 940x40 ad size from array

### DIFF
--- a/src/components/article/article.js
+++ b/src/components/article/article.js
@@ -522,7 +522,7 @@ export default class ArticleComponent extends Component {
    */
   _adSizes() {
     return googletag.sizeMapping()
-      .addSize([980, 0], [[970, 250], [940, 40], [728, 90]])
+      .addSize([980, 0], [[970, 250], [728, 90]])
       .addSize([728, 0], [[728, 90]])
       .addSize([0, 0], [[300, 250]])
       .build();


### PR DESCRIPTION
There aren't any 940x40 ads in the current campaign.