### PR TITLE
Update meta data for newly AJAX-loaded articles

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,10 @@
   "globals": {
     "$": true,
     "Modernizr": true,
-    "ENV_PROD": true
+    "ENV_PROD": true,
+    "ga": true,
+    "googletag": true,
+    "utag": true
   },
   "env": {
     "browser": true,


### PR DESCRIPTION
This pull request updates meta data for articles as they're loaded with AJAX and scrolled to. This also fixes an error on the `join` method where sometimes `interests` is a string instead of an array.