### PR TITLE
Tweak details-header mixin for photo credits; add basic "back" nav

### DIFF
--- a/sass/typography/_headings_mixins.scss
+++ b/sass/typography/_headings_mixins.scss
@@ -45,14 +45,34 @@
   font-size: 1.4rem;
 }
 
+// Very basic navigation header for Destinations sub-pages, i.e. photo credits
+@mixin details-nav() {
+  text-align: left;
+    max-width: $max-width;
+    margin: $gutter auto 0 auto;
+    padding-bottom: 2.5rem;
+
+    text-transform: uppercase;
+    border-bottom: 0.1rem solid #e4e4e4;
+
+    [class*="icon-chevron"] {
+      font-size: 7px;
+      vertical-align: 35%;
+      font-weight: 600;
+      margin-right: .8rem;
+      line-height: .5rem;
+    }
+}
+
 @mixin details-header() {
   @include container;
   padding-top: 5.8rem;
   position: relative;
+  padding-bottom: 3.2rem;
 
   @media (min-width: $min-720) {
     padding-bottom: 4.2rem;
-    padding-top: 13rem;
+    padding-top: 12rem;
   }
 
   &.is-narrow {

--- a/sass/typography/_headings_mixins.scss
+++ b/sass/typography/_headings_mixins.scss
@@ -46,7 +46,7 @@
 }
 
 // Very basic navigation header for Destinations sub-pages, i.e. photo credits
-@mixin details-nav() {
+@mixin narrative-nav() {
   text-align: left;
     max-width: $max-width;
     margin: $gutter auto 0 auto;

--- a/sass/typography/_headings_mixins.scss
+++ b/sass/typography/_headings_mixins.scss
@@ -56,7 +56,7 @@
     border-bottom: 0.1rem solid #e4e4e4;
 
     [class*="icon-chevron"] {
-      font-size: 7px;
+      font-size: .7rem;
       vertical-align: 35%;
       font-weight: 600;
       margin-right: .8rem;


### PR DESCRIPTION
This change is supplemental to the larger addition to Destinations Next of a photo credits page. Mixin for a stupid-simple nav was created because it will likely be used again in upcoming templates for Love Letter, etc.