### PR TITLE
Add a quick fix to wait for utag before tracking first ad impression

### DIFF
--- a/src/components/article/article.js
+++ b/src/components/article/article.js
@@ -38,7 +38,11 @@ export default class ArticleComponent extends Component {
     this._updateValuesAfterTimeout();
     this._setFirstArticle();
     this._createInitialListOfArticles();
-    this._loadFirstAd();
+
+    // Wait for utag
+    setTimeout(() => {
+      this._loadFirstAd();
+    }, 500);
 
     this.events = {
       "click .article-pagination__item": "_trackArticlePagination"


### PR DESCRIPTION
The problem is that `utag` is undefined when the page loads because it is loaded at the bottom of the page. Napkyn says "ideally [utag] `init` should be as close to the opening `<body>` tag as possible."

Therefore, I've added a `setTimeout` to wait until `utag` has been defined and then load the first add and track the impression. There may be a better way to do this, but for now, I believe this will do the trick.