### PR TITLE
Improve scroll to next feature for article experience

### DIFF
--- a/src/components/ads/ads.scss
+++ b/src/components/ads/ads.scss
@@ -39,7 +39,7 @@
 
 /// Adunit
 
-.adunit--leaderboard > div {
+.adunit {
   padding-bottom: 1.8rem;
   padding-top: 1.8rem;
 }

--- a/src/components/article/article-loading.scss
+++ b/src/components/article/article-loading.scss
@@ -1,12 +1,14 @@
+@import "../../../sass/webpack_deps";
+
 .article-loading {
   // border-top: .1rem solid $color-border;
+  opacity: 1;
   padding-top: gutter();
   padding-bottom: gutter();
   text-align: center;
+  transition: opacity $animation-speed ease;
 
-  span {
-    color: #ccc;
-    display: block;
-    font-size: 1.2rem;
+  &.is-invisible {
+    opacity: 0;
   }
 }

--- a/src/components/article/article.scss
+++ b/src/components/article/article.scss
@@ -3,6 +3,14 @@
 
 .article {
   position: relative;
+  opacity: 1;
+  transform: translateY(0);
+  transition: transform $animation-speed ease, opacity $animation-speed ease;
+
+  &.is-loading {
+    opacity: 0;
+    transform: translateY(20rem);
+  }
 }
 
 .article__container {


### PR DESCRIPTION
This update changes how the scroll to next feature works.

The calculations for loading articles has been improved. Instead of using each article's height and top offset, calculations using the document and window height are used. This allows the new article to be loaded near the bottom of the page and it removes the need to use `setTimeout` to get calculations.

Some updates have been made in order to animate the new article into place. Mostly just adding classnames and using the `waitForTransition` method.

A promise has been created for the next article AJAX call.

Styling updates have been made to the article and article loader in order to transition in/out when loaded/removed.

Lastly, made a small styling update to the ad component so that collapsed ads aren't shown.