### PR TITLE
Change :before and :after positioning to better hide TTD sliding imgs

### DIFF
--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -35,48 +35,15 @@
       top: 0%;
       background: #fff;
       z-index: 10;
-      width: 4%;
-
-
-      @media (min-width: $min-480) {
-        width: 8%;
-      }
-
-      @media (min-width: $min-1410) {
-        width: 25%;
-      }
+      width: 50%;
     }
 
     &:before {
-      left: -2rem;
-
-      @media (min-width: $min-480) {
-        left: -3rem;
-      }
-
-      @media (min-width: $min-840) {
-        left: -7%;
-      }
-
-      @media (min-width: $min-1410) {
-        left: -25%;
-      }
+      left: -50%;
     }
 
     &:after {
-      right: -2rem;
-
-      @media (min-width: $min-480) {
-        right: -3rem;
-      }
-
-      @media (min-width: $min-840) {
-        right: -7%;
-      }
-
-      @media (min-width: $min-1410) {
-        right: -25%;
-      }
+      right: -50%;
     }
   }
 

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -28,14 +28,14 @@
     }
 
     &:before, &:after {
+      background: #fff;
       content: "";
       display: block;
       height: 100%;
       position: absolute;
       top: 0%;
-      background: #fff;
-      z-index: 10;
       width: 50%;
+      z-index: 10;
     }
 
     &:before {


### PR DESCRIPTION
On certain wide displays the top experiences slideshow was not properly hiding the images as they slid in and out of view. This fix simplifies the CSS and does a better job of masking the moving images.