### PR TITLE
Add POI callout to article experience

### DIFF
--- a/sass/typography/_links_mixins.scss
+++ b/sass/typography/_links_mixins.scss
@@ -63,7 +63,7 @@
   }
 }
 
-/// Provides the underline for the fancy link
+/// Provides the underline for the `underlined-link` mixin
 /// @param {Color} $color [$color-blue] - Color of the underline, usually the same as the text color
 /// @param {Color} $background-color [#fff] Background color of the underline, usually the same color as the page; used for underline styles not solid
 /// @param {Dimension} $weight [.1rem] - Width of the underline

--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -1,21 +1,35 @@
 import { Component } from "../../core/bane";
 import $ from "jquery";
 import ImageGallery from "../image_gallery";
+import PoiCallout from "../poi_callout";
 import moment from "moment";
+import matchMedia from "../../core/utils/matchMedia";
 
 /**
  * Enhances the body of articles with a gallery and more
  */
 export default class ArticleBodyComponent extends Component {
-  initialize() {
+  initialize(options) {
     this.imageContainerSelector = ".stack__article__image-container";
+    this.poiData = options.poiData;
 
     this.loadImages().then(() => {
       this.gallery = new ImageGallery({
-        el: this.$el,
-        trackCategoryModifier: "article"
+        el: this.$el
       });
     });
+
+    if (this.poiData) {
+      matchMedia("(min-width: 1200px)", (query) => {
+        if (query.matches) {
+          this.loadPoiCallout(this.poiData);
+        } else {
+          if (typeof this.poiCallout !== "undefined") {
+            this.poiCallout.destroy();
+          }
+        }
+      });
+    }
 
     this.formatDate();
   }
@@ -93,5 +107,16 @@ export default class ArticleBodyComponent extends Component {
     $footer
       .find("time").html(formattedDate)
       .closest(".js-article-post-date").removeProp("hidden");
+  }
+
+  /**
+   * Creates a new instance of the POI callout
+   * @param {Object} data POI data
+   */
+  loadPoiCallout(data) {
+    this.poiCallout = new PoiCallout({
+      el: this.$el,
+      pois: data
+    });
   }
 }

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -252,20 +252,47 @@
   }
 
   a[data-callout-slug] {
-    @include underlined-link(
-      $link-color: $dark-blue,
-      $link-color-active: $color-blue
-    );
+    @media(max-width: $max-1200) {
+      @include underlined-link(
+        $link-color: $dark-blue,
+        $link-color-active: $color-blue
+      );
+    }
 
-    // @media(min-width: $min-1200) {
-    //   @include underlined-link(
-    //     $link-color: $dark-blue,
-    //     $link-color-active: $dark-blue,
-    //     $background-color: #fff,
-    //     $background-color-active: #f0f0f0,
-    //     $underline-style: dashed
-    //   );
-    // }
+    @media(min-width: $min-1200) {
+      backface-visibility: hidden;
+      border-bottom: 1px dashed #bbb;
+      box-shadow: 0 0 1px rgba(0, 0, 0, 0);
+      color: #2b3542;
+      position: relative;
+      text-decoration: none;
+      transform: translateZ(0);
+      transition: color .3, border-bottom .2s ease;
+
+      &:before {
+        background: #f0f0f0;
+        bottom: 0;
+        content: "";
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+        transform: scaleY(0);
+        transform-origin: 50% 100%;
+        transition: transform .1s ease, border-bottom .1s ease;
+        z-index: -1;
+      }
+
+      &:hover,
+      &:focus,
+      &.is-active {
+        border-bottom: 1px solid  #f0f0f0;
+
+        &:before {
+          transform: scaleY(1);
+        }
+      }
+    }
   }
 
   .client-strap {

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -262,7 +262,6 @@
     @media(min-width: $min-1200) {
       backface-visibility: hidden;
       border-bottom: 1px dashed #bbb;
-      box-shadow: 0 0 1px rgba(0, 0, 0, 0);
       color: #2b3542;
       position: relative;
       text-decoration: none;

--- a/src/components/poi_callout/poi_callout.js
+++ b/src/components/poi_callout/poi_callout.js
@@ -110,7 +110,7 @@ export default class PoiCalloutComponent extends Component {
       this.$callout
         .attr("aria-hidden", "true")
         .removeClass("is-visible");
-    }, 1000);
+    }, 250);
 
     return false;
   }
@@ -136,7 +136,7 @@ export default class PoiCalloutComponent extends Component {
    * Updates the callout content, makes it visible and positions it
    */
   _updatePoiCallout() {
-    let poiData = this.pois[this.$activeLink.data("poiSlug")];
+    let poiData = this.pois[this.$activeLink.data("calloutSlug")];
     let image, src;
 
     if (poiData.image) {

--- a/src/components/poi_callout/poi_callout.scss
+++ b/src/components/poi_callout/poi_callout.scss
@@ -29,7 +29,7 @@
 
   &.is-visible {
     opacity: 1;
-    transform: translate3d(-15px, 0, 0);
+    transform: translateX(-15px);
     transition: 0.2s ease 0.15s;
     visibility: visible;
   }


### PR DESCRIPTION
This update adds POI callouts back to articles. The AJAX call has been removed from the POI callout component because it's not needed. The AJAX call is made within the article component and then the data is passed into the POI callout component.

Link style has been changed for POI callouts; the underlined link mixin has been removed.

The delay to hide the callout has been reduced from 1000ms to 250ms.