### PR TITLE
Update fonts for webfont loader

### DIFF
--- a/sass/_base.scss
+++ b/sass/_base.scss
@@ -8,7 +8,7 @@ body {
   position: relative;
 
   line-height: $line-height;
-  font-family: $sans-serif;
+  font-family: $benton-sans;
   font-size: $base-size;
   color: $font-color;
 

--- a/sass/_fonts.scss
+++ b/sass/_fonts.scss
@@ -1,14 +1,14 @@
 /*
-This CSS resource incorporates links to font software which is 
-the valuable copyrighted property of WebType LLC, The Font Bureau, 
-and/or their suppliers. You may not 
-attempt to copy, install, redistribute, convert, modify or reverse 
-engineer this font software. Please contact WebType with any 
-questions: http://www.webtype.com 
+This CSS resource incorporates links to font software which is
+the valuable copyrighted property of WebType LLC, The Font Bureau,
+and/or their suppliers. You may not
+attempt to copy, install, redistribute, convert, modify or reverse
+engineer this font software. Please contact WebType with any
+questions: http://www.webtype.com
 */
 
 @font-face {
-  font-family: "Main";
+  font-family: "Benton Sans";
   src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot");
   src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot?") format("embedded-opentype"),
        url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-3.woff") format("woff"),
@@ -19,7 +19,7 @@ questions: http://www.webtype.com
 }
 
 @font-face {
-  font-family: "Main";
+  font-family: "Benton Sans";
   src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot");
   src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot?") format("embedded-opentype"),
        url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-3.woff") format("woff"),
@@ -30,7 +30,7 @@ questions: http://www.webtype.com
 }
 
 @font-face {
-  font-family: "Main";
+  font-family: "Benton Sans";
   src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot");
   src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot?") format("embedded-opentype"),
        url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-3.woff") format("woff"),
@@ -41,23 +41,23 @@ questions: http://www.webtype.com
 }
 
 @font-face {
-  font-family: "Secondary";
-  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-3.woff") format("woff"),
-       url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-1.ttf") format("truetype");
-  font-style: italic;
-  font-weight: normal;
-  font-stretch: normal;
-}
-
-@font-face {
-  font-family: "Secondary";
+  font-family: "Miller Daily";
   src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot");
   src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot?") format("embedded-opentype"),
        url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-1.ttf") format("truetype");
   font-style: normal;
+  font-weight: normal;
+  font-stretch: normal;
+}
+
+@font-face {
+  font-family: "Miller Daily";
+  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot");
+  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot?") format("embedded-opentype"),
+       url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-3.woff") format("woff"),
+       url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-1.ttf") format("truetype");
+  font-style: italic;
   font-weight: normal;
   font-stretch: normal;
 }

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -124,7 +124,7 @@
 @mixin author-name($mobile) {
   margin-bottom: .5rem;
   font: {
-    weight: $semibold;
+    weight: $font-weight-semibold;
     size: 4vw;
   }
   line-height: 1;
@@ -141,7 +141,7 @@
 /// @param {boolean} $mobile
 @mixin author-title($mobile) {
   font: {
-    family: $serif;
+    family: $miller-daily;
     style: italic;
     size: 4vw;
   }

--- a/sass/_text_mixins.scss
+++ b/sass/_text_mixins.scss
@@ -15,8 +15,8 @@
   color: $h2-color;
   font: {
     size: 19px;
-    family: $sans-serif;
-    weight: $semibold;
+    family: $benton-sans;
+    weight: $font-weight-semibold;
   }
 
   @include respond-to($mobile) {
@@ -31,8 +31,8 @@
   color: $tours-title-color;
   font: {
     size: 16px;
-    family: $sans-serif;
-    weight: $medium;
+    family: $benton-sans;
+    weight: $font-weight-medium;
   }
 
   @include respond-to($mobile) {
@@ -47,8 +47,8 @@
   color: $articles-blurb-color;
   font: {
     size: 14px;
-    family: $sans-serif;
-    weight: $medium;
+    family: $benton-sans;
+    weight: $font-weight-medium;
   }
 
   @include respond-to($mobile) {

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -18,8 +18,11 @@ $radius: .2rem;
 $base-size: 1.8em;
 
 // Typography
-$font-family: 'Main', sans-serif;
-$font-family-special: 'Secondary', serif;
+$sans-serif: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$serif: "Georgia", "Times", "Times New Roman", serif;
+$benton-sans: "Benton Sans", $sans-serif;
+$miller-daily: "Miller Daily", $serif;
+
 $font-size: #{strip-units($base-size)}rem;
 $font-color: #333;
 $font-color-light: #959aa0;
@@ -29,17 +32,16 @@ $font-weight-semibold: 600;
 $font-weight-bold: 700;
 $line-height: 1.5;
 
-
-// Typography legacy
-$sans-serif: $font-family;
-$serif: $font-family-special;
+// Typography (deprecated)
+$font-family: $benton-sans; // deprecated; use $benton-sans
+$font-family-special: $miller-daily; // deprecated; use $miller-daily
 $light: $font-weight-light;
 $medium: $font-weight-medium;
 $semibold: $font-weight-semibold;
 
 
 // Colors
-$color-warning: #FFC83F;
+$color-warning: #ffc83f;
 $color-blue: #287bbb;
 $color-lightblue: #e9f2f8;
 $color-darkblue: #2c3642;

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -24,8 +24,8 @@ $tablet-breakpoint: 1025;
   color: $h2-color;
   font: {
     size: 28px;
-    family: $sans-serif;
-    weight: $light;
+    family: $benton-sans;
+    weight: $font-weight-light;
   }
   line-height: 1.8;
   text-align: center;

--- a/sass/typography/_headings_mixins.scss
+++ b/sass/typography/_headings_mixins.scss
@@ -7,7 +7,7 @@
   margin-bottom: $margin-bottom;
   padding-bottom: $spacing;
 
-  font-family: $sans-serif;
+  font-family: $benton-sans;
   font-size: 2.8rem;
   font-weight: 100;
 

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -2,7 +2,7 @@
 
 // !important is needed to override specificity in article-body__content
 @mixin copy-caption {
-  font-family: "Main", sans-serif !important;
+  font-family: $benton-sans !important;
   font-size: 1.1rem !important;
   line-height: 1.4 !important;
   text-align: center !important;
@@ -58,7 +58,7 @@
     p:not(.copy--feature),
     .copy--body__list {
       color: $dark-blue;
-      font-family: "Secondary", serif;
+      font-family: $miller-daily;
       font-size: 1.6rem;
       line-height: (26 / 16);
 
@@ -346,7 +346,7 @@
 
 .article-post-date {
   color: $light-text-color;
-  font-family: "Main", sans-serif;
+  font-family: $benton-sans !important;
   font-size: 1.2rem;
   font-weight: 600;
   line-height: 1;

--- a/src/components/articles/_articles.scss
+++ b/src/components/articles/_articles.scss
@@ -80,9 +80,9 @@ $small-breakpoint: 320;
 
 .article__info__title {
   color: $h2-color;
-  font-family: $sans-serif;
+  font-family: $benton-sans;
   font-size: 1.9rem;
-  font-weight: $semibold;
+  font-weight: $font-weight-semibold;
   line-height: (27 / 19);
   letter-spacing: -.2px;
 
@@ -96,9 +96,9 @@ $small-breakpoint: 320;
 .article__info__teaser {
   margin-top: 1.9rem;
   color: $tours-title-color;
-  font-family: $sans-serif;
+  font-family: $benton-sans;
   font-size: 1.6rem;
-  font-weight: $medium;
+  font-weight: $font-weight-medium;
   line-height: (24 / 16);
   letter-spacing: .1px;
 
@@ -120,9 +120,9 @@ $small-breakpoint: 320;
 
 .article__info__blurb {
   color: $articles-blurb-color;
-  font-family: $sans-serif;
+  font-family: $benton-sans;
   font-size: 1.4rem;
-  font-weight: $medium;
+  font-weight: $font-weight-medium;
   line-height: (24 / 14);
   letter-spacing: .1px;
   margin-top: .8rem;

--- a/src/components/author/author.scss
+++ b/src/components/author/author.scss
@@ -137,7 +137,7 @@ $author: (
 .author__name {
   color: $body-color;
   font-size: 1.2rem;
-  font-weight: $semibold;
+  font-weight: $font-weight-semibold;
   line-height: 1;
 
   @media(#{get($author, 'mq-min')}) {
@@ -181,7 +181,7 @@ $author: (
   line-height: 1;
 
   &:not(.is-inline) {
-    font-family: $serif;
+    font-family: $miller-daily;
     font-style: italic;
     letter-spacing: 0;
   }

--- a/src/components/food_and_drink/_food_and_drink.scss
+++ b/src/components/food_and_drink/_food_and_drink.scss
@@ -10,7 +10,7 @@ $item-border-color: #f1f4fb;
 .food-and-drink {
   position: relative;
   margin-bottom: $spacing;
-  font-weight: $medium;
+  font-weight: $font-weight-medium;
 
   @media (min-width: $min-960) {
     min-height: 400px;
@@ -116,7 +116,7 @@ $item-border-color: #f1f4fb;
     white-space: nowrap;
     overflow: hidden;
   }
-  
+
   &__name{
     color: $color-darkblue;
   }

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -244,7 +244,7 @@ $logo-height: 4rem;
 }
 
 .footer__main__links__header {
-  font-weight: $semibold;
+  font-weight: $font-weight-semibold;
   font-size: 1.2rem;
   line-height: 1;
   text-transform: uppercase;

--- a/src/components/love_letter/_love_letter.scss
+++ b/src/components/love_letter/_love_letter.scss
@@ -39,7 +39,7 @@ $small-breakpoint: 320;
 
   &__text {
     margin: 0 auto 5.5rem;
-    font-family: $font-family;
+    font-family: $benton-sans;
     font-style: italic;
     font-size: $font-size;
     color: #67747d;

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -205,7 +205,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     position: absolute;
     left: 0;
     width: 100%;
-    font-family: $serif;
+    font-family: $miller-daily;
     font-style: italic;
     font-size: 2rem;
     letter-spacing: .1rem;
@@ -255,7 +255,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     color: #fff;
     line-height: 1;
     cursor: pointer;
-    
+
     .is-visible {
       display: block;
     }
@@ -338,9 +338,9 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
       margin-top: 0;
     }
   }
-  
+
   &__video-container {
-    width: 100%; 
+    width: 100%;
     height: 100%;
 
     .masthead--narrow & {
@@ -368,7 +368,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     // above slideshow
     z-index: 4;
     opacity: 0;
-    transition: .2s opacity; 
+    transition: .2s opacity;
 
     &.is-playing {
       display: block;

--- a/src/components/navigation/_navigation.scss
+++ b/src/components/navigation/_navigation.scss
@@ -106,7 +106,7 @@
     width: $size;
     height: $size;
 
-    font-family: $font-family;
+    font-family: $benton-sans;
     font-size: 1.3rem;
     font-weight: 600;
     color: #fff;

--- a/src/components/poi_callout/poi_callout.scss
+++ b/src/components/poi_callout/poi_callout.scss
@@ -59,7 +59,7 @@
 
 .poi-callout__content h5 {
   color: #6d6d6d;
-  font-family: "Secondary", serif;
+  font-family: $miller-daily;
   font-size: 1.6rem;
   font-style: italic;
   font-weight: 300;

--- a/src/components/survival_guide/_survival_guide.scss
+++ b/src/components/survival_guide/_survival_guide.scss
@@ -4,7 +4,7 @@ $tablet-breakpoint: 700;
 $mobile-breakpoint: 400;
 
 .survival-guide {
-  font-weight: $medium;
+  font-weight: $font-weight-medium;
   text-align: center;
 
   &__heading {

--- a/src/components/things_to_do/_things_to_do.scss
+++ b/src/components/things_to_do/_things_to_do.scss
@@ -207,7 +207,7 @@
     width: $size;
     height: $size;
 
-    font-family: $font-family-special;
+    font-family: $miller-daily;
     font-size: 1.4rem;
     line-height: $size;
     text-align: center;
@@ -256,7 +256,7 @@
   }
 
   &__subtitle {
-    font-family: $font-family-special;
+    font-family: $miller-daily;
     font-style: italic;
     font-size: 1.2rem;
     line-height: 1;

--- a/src/components/top_places/_top_places.scss
+++ b/src/components/top_places/_top_places.scss
@@ -72,7 +72,7 @@
     width: $size;
     height: $size;
 
-    font-family: $sans-serif;
+    font-family: $benton-sans;
     font-size: 1.2rem;
     color: $font-color;
     text-align: center;
@@ -170,7 +170,7 @@
       left: -4rem;
       width: 3rem;
       text-align: right;
-      font-family: $font-family-special;
+      font-family: $miller-daily;
       font-weight: 500;
       color: #a7a9ae;
       counter-increment: tlist;

--- a/src/components/tours/_tours.scss
+++ b/src/components/tours/_tours.scss
@@ -89,7 +89,7 @@ $tours-width: 52rem / $tours-width-base * 100%;
 }
 
 .tour__description {
-  font-weight: $medium;
+  font-weight: $font-weight-medium;
   color: $tours-title-color;
 
   @media (min-width: $min-960) {
@@ -133,7 +133,7 @@ $tours-width: 52rem / $tours-width-base * 100%;
   margin-right: $gutter - .5rem;
   padding: .5rem .8rem .4rem;
   font-size: 1.2rem;
-  font-weight: $semibold;
+  font-weight: $font-weight-semibold;
   line-height: 1;
   background-color: $tours-price-background;
   text-align: center;
@@ -148,7 +148,7 @@ $tours-width: 52rem / $tours-width-base * 100%;
 
 .tour__imagery__caption__type {
   font-size: 1.1rem;
-  font-weight: $semibold;
+  font-weight: $font-weight-semibold;
   text-transform: uppercase;
   color: $tours-title-color;
   overflow: hidden;


### PR DESCRIPTION
This pull request makes some changes to fonts and font variables.

#### Rename custom fonts

These names are now representative of the each font's actual name. Ideally, the fonts should be declared by their actual names and not a keyword. "Main" and "secondary" are too ambiguous. What would happen if a third font was added? Consider the approach taken by Typekit and Google Fonts.

Anyone looking at the code now will be able to identify what font is being used where without having to know that a specific keyword matches a certain font.

This update will also benefit the webfont loader because the fonts need to be declared within the loader, so it'll help if the names are descriptive.

#### Update font variables

A number of updates have been made to how font variables are defined and some variables have been deprecated.

1. `$sans-serif` and `$serif` variables mapped to `$font-family` and `$font-family-special`, respectively. There isn't a need to redefine these variables with a different name. Therefore, `$sans-serif` and `$serif` have been updated to declare a font stack. These stacks can be used independently or appended to custom fonts. They use the generic variable names `$sans-serif` and `$serif` because they are to be treated as generic fonts that aren't technically part of the design but to be used as fallbacks.
2. `$font-family` and `$font-family-special` have been deprecated. These variable names are rather ambiguous and don't describe which font is being used, which leads to #3.
3. `$benton-sans` and `$miller-daily` variables have been created. Since each custom font's name was changed to be more descriptive, these new variables serve the same purpose. With these new variables, it will be clear what font is being requested.
4. `$light`, `$medium`, `$semibold` have been replaced and deprecated. Again, these variables only serve to redefine variables that have already been created. `$font-weight-light`, `$font-weight-medium`, `$font-weight-semibold` have been kept because they are more descriptive. Deprecated variables should be removed in a future release.

#### Update files to add new variables and replace deprecated ones

Of course this needs to be done so the stylesheets don't break.