### PR TITLE
Update mixin names

### DIFF
--- a/src/components/map/sidebar/sidebar.scss
+++ b/src/components/map/sidebar/sidebar.scss
@@ -121,7 +121,7 @@ $panel-height: calc(100% - #{$sidebar-header-height});
         $width: 28rem;
         $margin-left: 0;
         $padding-top: ($gutter * 1.5) - 1.3rem;
-        @include dropdownMenu($top, $left, $width, $margin-left, $padding-top);
+        @include dropdown-menu($top, $left, $width, $margin-left, $padding-top);
         padding-left: ($gutter + .8rem);
         padding-bottom: ($gutter - 1.3rem);
         padding-right: $gutter;
@@ -129,11 +129,11 @@ $panel-height: calc(100% - #{$sidebar-header-height});
         &:before {
           $size: 1.2rem;
           $left: 5.8rem;
-          @include dropdownMenuArrow($size, $left);
+          @include dropdown-menu-arrow($size, $left);
         }
 
         &.is-visible {
-          @include dropdownMenuVisible;
+          @include dropdown-menu-visible;
         }
       }
 

--- a/src/components/navigation/_navigation.scss
+++ b/src/components/navigation/_navigation.scss
@@ -39,7 +39,7 @@
     }
 
     &--user > a {
-      @include buttonBorder;
+      @include button-border;
       line-height: 0;
 
       &.avatar {
@@ -48,7 +48,7 @@
       }
 
       .navigation--narrow & {
-        @include buttonBorder(#BEBEBE)
+        @include button-border(#bebebe);
 
         &:hover {
           border-color: $color-primary;
@@ -129,10 +129,10 @@
   $width: 29rem;
   $margin-left: -($width / 2);
   $padding-top: 0;
-  @include dropdownMenu($top, $left, $width, $margin-left, $padding-top);
+  @include dropdown-menu($top, $left, $width, $margin-left, $padding-top);
 
   &:before {
-    @include dropdownMenuArrow;
+    @include dropdown-menu-arrow;
   }
 
   // The last subnav item gets hidden when the screen smaller
@@ -144,14 +144,14 @@
         left: auto;
       }
 
-      left: auto; 
+      left: auto;
       right: 0;
       margin-left: 0;
     }
   }
 
   &--visible {
-    @include dropdownMenuVisible;
+    @include dropdown-menu-visible;
   }
 
   &__list {

--- a/src/components/navigation/_sub-navigation.scss
+++ b/src/components/navigation/_sub-navigation.scss
@@ -6,14 +6,14 @@
   $width: 29rem;
   $margin-left: -($width / 2);
   $padding-top: 0;
-  @include dropdownMenu($top, $left, $width, $margin-left, $padding-top);
+  @include dropdown-menu($top, $left, $width, $margin-left, $padding-top);
 
   &:before {
-    @include dropdownMenuArrow;
+    @include dropdown-menu-arrow;
   }
 
   &--visible {
-    @include dropdownMenuVisible;
+    @include dropdown-menu-visible;
   }
 
   &__list {

--- a/src/components/navigation/_user-panel.scss
+++ b/src/components/navigation/_user-panel.scss
@@ -12,11 +12,11 @@ $user-panel: (
   $width: 29rem;
   $margin-left: -($width / 2);
   $padding-top: 0;
-  @include dropdownMenu($top, $left, $width, $margin-left, $padding-top);
-  @include dropdownMenuVisible;
+  @include dropdown-menu($top, $left, $width, $margin-left, $padding-top);
+  @include dropdown-menu-visible;
 
   &:before {
-    @include dropdownMenuArrow;
+    @include dropdown-menu-arrow;
   }
 }
 


### PR DESCRIPTION
There are some mixins that have been renamed to conform with SCSS linting rules that have not been updated in src/components. This fixes errors until the refactor of src/components is completed.