### PR TITLE
Update sights component to match design

### DIFF
--- a/sass/elements/_buttons_mixins.scss
+++ b/sass/elements/_buttons_mixins.scss
@@ -30,8 +30,8 @@
 
   [class*="icon-"] {
     display: inline-block;
-    font-size: .6rem;
-    margin-left: .6rem;
+    font-size: 6px;
+    margin-left: 6px;
     transform: translate3d(0, 0, 0);
     transition: transform 500ms;
     vertical-align: 20%;

--- a/sass/typography/_links_mixins.scss
+++ b/sass/typography/_links_mixins.scss
@@ -32,9 +32,9 @@
   [class*="icon-"] {
     backface-visibility: hidden;
     display: inline-block;
-    font-size: .6rem;
+    font-size: 6px;
     line-height: 1.6;
-    transform: translateX(.6rem);
+    transform: translateX(6px);
     transition: transform 500ms;
     vertical-align: 20%;
   }

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -1,171 +1,188 @@
-@import "../../../sass/webpack_deps";
-$image-width: 5.5rem;
-$order-width: 4.5rem;
-$toggle-width: 10vw;
+@import '../../../sass/webpack_deps';
 
 .sights {
-  @include container-static(12);
-  padding: 0 1rem;
-  counter-reset: sight-count;
+  counter-reset: sights-count;
 
-  &__heading--small {
+  @media (max-width: $max-960) {
+    padding-bottom: 3rem;
+  }
+}
+
+.sights__more {
+  @include more();
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 4.5rem;
+
+  @media (min-width: $min-960) {
+    margin-top: 7rem;
+  }
+}
+
+.sights__heading {
+  color: #3b444f;
+  font-size: 2rem;
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -.01rem;
+  padding-bottom: 2.4rem;
+  padding-top: 3rem;
+
+  @media (max-width: $max-960) {
     text-align: center;
-    padding-bottom: 1rem;
+  }
 
+  @media (min-width: $min-960) {
+    font-size: 2.6rem;
+  }
+}
+
+.sights__list {
+  @media (min-width: $min-600) {
+    display: flex;
+  }
+
+  .no-flexbox & {
+    @include clearfix;
+  }
+}
+
+.sights__column {
+  @media (min-width: $min-600) {
+    flex-grow: 1;
+    width: span(6);
+  }
+
+  @media (min-width: $min-960) {
+    width: span(4);
+  }
+
+  .no-flexbox & {
     @media (min-width: $min-600) {
-      text-align: left;
+      float: left;
     }
   }
 
-  &__heading--large {
-    @include h1();
-  }
-
-  &__list, &__heading--small {
-    margin: 0 auto;
-
-    @media (min-width: $min-720) {
-      width: 90%;
-    }
-
-    @media (min-width: $min-840) {
-      width: 80%;
-    }
-
-    @media (min-width: $min-960) {
-      width: 100%;
-    }
-  }
-
-  &__column {
+  &:not(:first-child) {
     @media (min-width: $min-600) {
-      @include gallery(6 of 12);
+      margin-left: 3rem;
     }
+  }
 
+  &:nth-child(2) {
+    .sights__item:first-child {
+      @media (max-width: $max-600) {
+        border-top: 0;
+      }
+    }
+  }
+
+  &:nth-child(3) {
+    @media (max-width: $max-960) {
+      display: none;
+    }
+  }
+}
+
+.sights__column--half {
+  .no-flexbox & {
     @media (min-width: $min-960) {
-      @include gallery(4 of 12);
+      width: span(6);
     }
+  }
+}
 
-    .sights__item:first-child:before {
-      content: "";
-      position: absolute;
-      top: -.3rem;
-      left: 0;
-      display: block;
-      height: 0;
-      width: 100%;
+.sights__item {
+  align-items: center;
+  border-bottom: .1rem solid $divider-color;
+  display: flex;
+  padding-bottom: .8rem;
+  padding-top: .8rem;
+  position: relative;
+
+  &:first-child {
+    @media (min-width: $min-600) {
       border-top: .1rem solid $divider-color;
     }
   }
 
-  &__column--3 {
-    display: none;
-
-    @media (min-width: $min-960) {
-      display: inline-block;
+  &:last-child {
+    .sights__column:nth-child(2) & {
+      @media (max-width: $max-600) {
+        border-bottom: 0;
+      }
     }
   }
+}
 
-  &__item {
-    height: 5rem;
+.sights__text {
+  margin-left: 3rem;
+  width: calc(100% - 6rem - 3rem - 2rem);
+}
+
+.sights__title {
+  color: #030f1d;
+  font-size: 1.6rem;
+  font-weight: 600;
+  line-height: 1.7;
+  transition: color $animation-speed ease;
+
+  .sights__item:hover &,
+  .sights__item:active &,
+  .sights__item:focus & {
+    color: $color-blue;
+  }
+}
+
+.sights__location {
+  color: #c5d1d7;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: .02rem;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.sights__title,
+.sights__location {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sights__count {
+  $size: 3rem;
+  display: block;
+  height: $size;
+  left: (($size * 2) + .5);
+  line-height: 1;
+  position: absolute;
+  text-align: center;
+  top: 50%;
+  transform: translate(0, -50%);
+  width: $size;
+
+  &::before {
+    background-color: #fff;
+    border-radius: .4rem;
+    box-shadow: .2rem .1rem .4rem -.2rem #333;
+    content: '';
+    display: block;
+    height: 100%;
+    left: 50%;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%) rotate(45deg);
+    width: 100%;
+  }
+
+  &::after {
+    content: counter(sights-count);
+    counter-increment: sights-count;
+    color: $feature-copy;
+    font-size: 1.3rem;
     position: relative;
-    cursor: pointer;
-    margin-top: .5rem;
-
-    &:after {
-      position: absolute;
-      display: block;
-      height: 0;
-      width: 100%;
-      border-top: .1rem solid $divider-color;
-      content: "";
-      bottom: -.3rem;
-      left: 0;
-    }
-
-    &__img {
-      background-size: cover;
-      background-repeat: no-repeat;
-      height: 4rem;
-      width: $image-width;
-      overflow: hidden;
-      position: absolute;
-      top: calc(50% - 2rem);
-      left: 0;
-
-      &:before {
-        width: $image-width;
-        background-position: center -63px;
-      }
-    }
-
-    &__text {
-      position: absolute;
-      top: 50%;
-      transform: translate(0, -50%);
-      left: $image-width + 2rem;
-      width: calc(100% - #{$image-width} - #{$order-width});
-
-      .title {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        font-size: 1.2rem;
-        font-weight: 600;
-        color: $color-darkblue;
-        transition: color $animation-speed ease;
-      }
-
-      .subtitle {
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        color: $footer-bottom-link-color;
-        font-size: .9rem;
-        font-weight: 600;
-        text-transform: uppercase;
-      }
-    }
-
-    &:hover {
-      .title {
-        color: $color-blue;
-      }
-    }
-
-    &__order {
-      position: absolute;
-      width: $order-width;
-      height: $order-width;
-      display: block;
-      left: $image-width - .1rem;
-      top: 50%;
-      transform: translate(-50%, -50%);
-      text-align: center;
-      line-height: $order-width;
-      font-weight: bold;
-      color: $feature-copy;
-      font-size: 1rem;
-
-      &:before {
-        position: absolute;
-        display: block;
-        background-color: #fff;
-        top: 50%;
-        left: 50%;
-        width: 40%;
-        height: 40%;
-        transform: translate(-50%, -50%) rotate(45deg);
-        content: "";
-        z-index: -1;
-        box-shadow: .2rem .1rem .4rem -.2rem #333;
-        border-radius: .4rem;
-      }
-
-      &:after {
-        counter-increment: sight-count;
-        content: counter(sight-count);
-      }
-    }
+    top: .6rem;
   }
 }

--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -21,21 +21,27 @@
 }
 
 .sights__heading {
-  color: #3b444f;
-  font-size: 2rem;
-  font-weight: 300;
-  line-height: 1;
-  letter-spacing: -.01rem;
-  padding-bottom: 2.4rem;
-  padding-top: 3rem;
+  &:not(.sights__heading--large) {
+    color: $h2-color;
+    font-size: 2rem;
+    font-weight: 300;
+    line-height: 1;
+    letter-spacing: -.01rem;
+    padding-bottom: 2.4rem;
+    padding-top: 3rem;
 
-  @media (max-width: $max-960) {
-    text-align: center;
-  }
+    @media (max-width: $max-960) {
+      text-align: center;
+    }
 
-  @media (min-width: $min-960) {
-    font-size: 2.6rem;
+    @media (min-width: $min-960) {
+      font-size: 2.6rem;
+    }
   }
+}
+
+.sights__heading--large {
+  @include h1();
 }
 
 .sights__list {

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,7 +1,7 @@
 <article class="sights">
-  <h3 class="sights__heading">
+  <h2 class="sights__heading js-sights-heading">
     {{sights_title}}
-  </h3>
+  </h2>
 
   <div class="sights__list">
     {{#if show}}

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,87 +1,9 @@
-<article class="sights">
+<article class="sights" data-lp-initial-sights="{{sights.json}}">
   <h2 class="sights__heading js-sights-heading">
     {{sights_title}}
   </h2>
 
-  <div class="sights__list">
-    {{#if show}}
-
-      <div class="sights__column{{#unless third_column}} sights__column--half{{/unless}}">
-        {{#each first_column}}
-          <a class="sights__item" href="/{{slug}}">
-            {{#if img_url}}
-              <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
-            {{else}}
-              <div class="topic__image--sight"></div>
-            {{/if}}
-
-            <div class="sights__text">
-              <h5 class="sights__title">
-                {{title}}
-              </h5><!-- .sights__title -->
-
-              <div class="sights__location">
-                {{subtitle}}
-              </div><!-- .sights__location -->
-            </div><!-- .sights__text -->
-
-            <div class="sights__count"></div>
-          </a><!-- .sights__item -->
-        {{/each}}
-      </div><!-- .sights__column -->
-
-      <div class="sights__column{{#unless third_column}} sights__column--half{{/unless}}">
-        {{#each second_column}}
-          <a class="sights__item" href="/{{slug}}">
-            {{#if img_url}}
-              <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
-            {{else}}
-              <div class="topic__image--sight"></div>
-            {{/if}}
-
-            <div class="sights__text">
-              <h5 class="sights__title">
-                {{title}}
-              </h5><!-- .sights__title -->
-
-              <div class="sights__location">
-                {{subtitle}}
-              </div><!-- .sights__location -->
-            </div><!-- .sights__text -->
-
-            <div class="sights__count"></div>
-          </a><!-- .sights__item -->
-        {{/each}}
-      </div><!-- .sights__column -->
-
-      {{#if third_column}}
-        <div class="sights__column">
-          {{#each third_column}}
-            <a class="sights__item" href="/{{slug}}">
-              {{#if img_url}}
-                <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
-              {{else}}
-                <div class="topic__image--sight"></div>
-              {{/if}}
-
-              <div class="sights__text">
-                <h5 class="sights__title">
-                  {{title}}
-                </h5><!-- .sights__title -->
-
-                <div class="sights__location">
-                  {{subtitle}}
-                </div><!-- .sights__location -->
-              </div><!-- .sights__text -->
-
-              <div class="sights__count"></div>
-            </a><!-- .sights__item -->
-          {{/each}}
-        </div><!-- .sights__column -->
-      {{/if}}
-
-    {{/if}}
-  </div><!-- .sights__list -->
+  <div class="js-sights-list"></div>
 
   <a class="sights__more" href="#">
     See all sights

--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -1,64 +1,90 @@
 <article class="sights">
-  <h3 class="sights__heading sights__heading--small">{{sights_title}}</h3>
-  <h2 class="sights__heading sights__heading--large is-hidden">{{sights_title}}</h2>
+  <h3 class="sights__heading">
+    {{sights_title}}
+  </h3>
+
   <div class="sights__list">
-  {{#if show}}
-    <div class="sights__column sights__column--1">
-    {{#each first_column}}
-      <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{slug}}">
-          {{#if img_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
+    {{#if show}}
+
+      <div class="sights__column{{#unless third_column}} sights__column--half{{/unless}}">
+        {{#each first_column}}
+          <a class="sights__item" href="/{{slug}}">
+            {{#if img_url}}
+              <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
             {{else}}
-            <div class="sights__item__img topic__image--sight"></div>
-          {{/if}}
-          <div class="sights__item__order"></div>
-          <div class="sights__item__text">
-            <div class="title">{{title}}</div>
-            <div class="subtitle">{{subtitle}}</div>
-          </div>
-        </a>
-      </div>
-    {{/each}}
-    </div>
-    <div class="sights__column sights__column--2">
-    {{#each second_column}}
-      <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{slug}}">
-          {{#if img_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
+              <div class="topic__image--sight"></div>
+            {{/if}}
+
+            <div class="sights__text">
+              <h5 class="sights__title">
+                {{title}}
+              </h5><!-- .sights__title -->
+
+              <div class="sights__location">
+                {{subtitle}}
+              </div><!-- .sights__location -->
+            </div><!-- .sights__text -->
+
+            <div class="sights__count"></div>
+          </a><!-- .sights__item -->
+        {{/each}}
+      </div><!-- .sights__column -->
+
+      <div class="sights__column{{#unless third_column}} sights__column--half{{/unless}}">
+        {{#each second_column}}
+          <a class="sights__item" href="/{{slug}}">
+            {{#if img_url}}
+              <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
             {{else}}
-            <div class="sights__item__img topic__image--sight"></div>
-          {{/if}}
-          <div class="sights__item__order"></div>
-          <div class="sights__item__text">
-            <div class="title">{{title}}</div>
-            <div class="subtitle">{{subtitle}}</div>
-          </div>
-        </a>
-      </div>
-    {{/each}}
-    </div>
-    {{#if third_column}}
-    <div class="sights__column sights__column--3">
-      {{#each third_column}}
-      <div class="sights__item">
-        <a href="http://www.lonelyplanet.com/{{slug}}">
-          {{#if img_url}}
-            <div class="sights__item__img" style="background-image: url('http://images-resrc.staticlp.com/O=60/S=W80/{{img_url}}')"></div>
-            {{else}}
-            <div class="sights__item__img topic__image--sight"></div>
-          {{/if}}
-          <div class="sights__item__order"></div>
-          <div class="sights__item__text">
-            <div class="title">{{title}}</div>
-            <div class="subtitle">{{subtitle}}</div>
-          </div>
-        </a>
-      </div>
-      {{/each}}
-    </div>
+              <div class="topic__image--sight"></div>
+            {{/if}}
+
+            <div class="sights__text">
+              <h5 class="sights__title">
+                {{title}}
+              </h5><!-- .sights__title -->
+
+              <div class="sights__location">
+                {{subtitle}}
+              </div><!-- .sights__location -->
+            </div><!-- .sights__text -->
+
+            <div class="sights__count"></div>
+          </a><!-- .sights__item -->
+        {{/each}}
+      </div><!-- .sights__column -->
+
+      {{#if third_column}}
+        <div class="sights__column">
+          {{#each third_column}}
+            <a class="sights__item" href="/{{slug}}">
+              {{#if img_url}}
+                <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
+              {{else}}
+                <div class="topic__image--sight"></div>
+              {{/if}}
+
+              <div class="sights__text">
+                <h5 class="sights__title">
+                  {{title}}
+                </h5><!-- .sights__title -->
+
+                <div class="sights__location">
+                  {{subtitle}}
+                </div><!-- .sights__location -->
+              </div><!-- .sights__text -->
+
+              <div class="sights__count"></div>
+            </a><!-- .sights__item -->
+          {{/each}}
+        </div><!-- .sights__column -->
+      {{/if}}
+
     {{/if}}
-  {{/if}}
-  </div>
-</article>
+  </div><!-- .sights__list -->
+
+  <a class="sights__more" href="#">
+    See all sights
+    <i class="icon-chevron-right" aria-hidden="true"></i>
+  </a>
+</article><!-- .sights -->

--- a/src/components/sights/sights_component.js
+++ b/src/components/sights/sights_component.js
@@ -5,8 +5,9 @@ export default class Sights extends Component {
   initialize() {
     this.subscribe();
   }
-  @subscribe("ttd.removed", "components")
+
+  @subscribe("ttd.removed", "components");
   _changeTitle() {
-    this.$el.find(".sights__heading").toggleClass("is-hidden");
+    this.$el.find(".js-sights-heading").toggleClass("sights__heading--large");
   }
 }

--- a/src/components/sights/sights_component.js
+++ b/src/components/sights/sights_component.js
@@ -3,6 +3,9 @@ import subscribe from "../../core/decorators/subscribe";
 
 export default class Sights extends Component {
   initialize() {
+    let sights = this.getInitialState();
+    this.sightsList = require("./sights_list.hbs");
+    this.$el.find(".js-sights-list").replaceWith(this.sightsList(sights));
     this.subscribe();
   }
 

--- a/src/components/sights/sights_item.hbs
+++ b/src/components/sights/sights_item.hbs
@@ -1,0 +1,19 @@
+<a class="sights__item" href="https://www.lonelyplanet.com/{{slug}}">
+  {{#if img_url}}
+    <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
+  {{else}}
+    <div class="topic__image--sight"></div>
+  {{/if}}
+
+  <div class="sights__text">
+    <h5 class="sights__title">
+      {{title}}
+    </h5><!-- .sights__title -->
+
+    <div class="sights__location">
+      {{subtitle}}
+    </div><!-- .sights__location -->
+  </div><!-- .sights__text -->
+
+  <div class="sights__count"></div>
+</a><!-- .sights__item -->

--- a/src/components/sights/sights_item.hbs
+++ b/src/components/sights/sights_item.hbs
@@ -1,4 +1,4 @@
-<a class="sights__item" href="https://www.lonelyplanet.com/{{slug}}">
+<a class="sights__item" href="/{{slug}}">
   {{#if img_url}}
     <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
   {{else}}

--- a/src/components/sights/sights_list.hbs
+++ b/src/components/sights/sights_list.hbs
@@ -1,0 +1,25 @@
+<div class="sights__list">
+  {{#if sights.show}}
+
+    <div class="sights__column{{#unless sights.third_column}} sights__column--half{{/unless}}">
+      {{#each sights.first_column}}
+        {{> "sights_item"}}
+      {{/each}}
+    </div><!-- .sights__column -->
+
+    <div class="sights__column{{#unless sights.third_column}} sights__column--half{{/unless}}">
+      {{#each sights.second_column}}
+        {{> "sights_item"}}
+      {{/each}}
+    </div><!-- .sights__column -->
+
+    {{#if sights.third_column}}
+      <div class="sights__column">
+        {{#each sights.third_column}}
+          {{> "sights_item"}}
+        {{/each}}
+      </div><!-- .sights__column -->
+    {{/if}}
+
+  {{/if}}
+</div><!-- .sights__list -->


### PR DESCRIPTION
This pull request updates the sights component to match the design, but also has been refactored to remove complexity. The layout now uses flexbox.

One thing that I don't like is how `sights__item` is repeated 3 times in sights.hbs. I've created sights_item.hbs, but I can't include the partial inside of an `{{#each}}`. 

What I would like to do is this:

```handlebars
{{#each first_column}}
  {{> "components/sights/sights_item" }}
{{/each}}
```

But that causes the following error in Ruby:

```
undefined method `render' for #<OpenStruct …
```

Any suggestions?