### PR TITLE
Fix missing fallback image for sights

### DIFF
--- a/src/components/sights/_sights.scss
+++ b/src/components/sights/_sights.scss
@@ -1,4 +1,5 @@
 @import '../../../sass/webpack_deps';
+@import '../topic/topic';
 
 .sights {
   counter-reset: sights-count;
@@ -120,6 +121,10 @@
       }
     }
   }
+}
+
+.sights__image {
+  position: static;
 }
 
 .sights__text {

--- a/src/components/sights/sights_item.hbs
+++ b/src/components/sights/sights_item.hbs
@@ -2,7 +2,7 @@
   {{#if img_url}}
     <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
   {{else}}
-    <div class="topic__image--sight"></div>
+    <div class="sights__image topic__image topic__image--sight"></div>
   {{/if}}
 
   <div class="sights__text">


### PR DESCRIPTION
Import topic partial and reset `position` of `topic__image` (`sights__image`) to `static`.