### PR TITLE
Update sub-nav component, experiences (ttd) link

### DIFF
--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -11,6 +11,9 @@ export default class SubNav extends Component {
         $window = $(window);
 
     this.contentHeight = 0;
+    this.$subNavList = this.$el.find(".js-sub-nav-list");
+
+    this.subNavItem = require("./sub_nav_item.hbs");
 
     /**
      * Checks to see if a given element has been scrolled into view
@@ -29,6 +32,9 @@ export default class SubNav extends Component {
     if ($subNav.length) {
       let subNavTop = $subNav.offset().top,
           firstTrigger = true;
+
+      this.subscribe();
+      this.addClientSideComponents();
 
       $(document).on("click", ".js-sub-nav-link", function(e) {
         let target = this.hash;
@@ -57,7 +63,7 @@ export default class SubNav extends Component {
             return document.getElementById(el.href.split("#")[1]);
           });
 
-      $window.scroll(debounce(() => {
+      $window.on("scroll", debounce(() => {
         if (firstTrigger) {
           firstTrigger = false;
         }
@@ -109,21 +115,16 @@ export default class SubNav extends Component {
 
       }, 10));
 
-      $window.resize(debounce(() => {
+      $window.on("resize", debounce(() => {
         this.updateContentHeight();
       }, 10));
     }
-
-    this.subscribe();
-    this.addClientSideComponents();
   }
   addClientSideComponents() {
-    // TODO: Handlebars template perhaps? More dynamic perhaps?
-    $(
-    `<li class="sub-nav__item sub-nav__item--ttd">
-      <a class="sub-nav__link js-sub-nav-link" href="#ttd">experiences</a>
-    </li>
-    `).prependTo(this.$el.find(".sub-nav__list"));
+    $(this.subNavItem({
+      id: "experiences",
+      title: "Experiences"
+    })).prependTo(this.$subNavList);
   }
   @subscribe(RizzoEvents.LOAD_BELOW, "events");
   updateContentHeight() {
@@ -132,18 +133,17 @@ export default class SubNav extends Component {
   /**
    * If a component is removed from the DOM, this will remove its subnav element
    */
-  @subscribe("*.removed", "components")
+  @subscribe("*.removed", "components");
   removeSubNav(data, envelope) {
     let component = envelope.topic.split(".")[0];
 
     this.$el.find(`.sub-nav__item--${component}`).remove();
   }
-  @subscribe("ttd.removed", "components")
+  @subscribe("ttd.removed", "components");
   addSights() {
-    $(
-    `<li class="sub-nav__item sub-nav__item--sights">
-      <a class="sub-nav__link js-sub-nav-link" href="#sights">sights</a>
-    </li>
-    `).prependTo(this.$el.find(".sub-nav__list"));
+    $(this.subNavItem({
+      id: "sights",
+      title: "Sights"
+    })).prependTo(this.$subNavList);
   }
 }

--- a/src/components/sub_nav/sub_nav.hbs
+++ b/src/components/sub_nav/sub_nav.hbs
@@ -2,7 +2,7 @@
 <nav id="sub-nav" class="sub-nav js-sub-nav">
   <div class="sub-nav__wrap">
     <div class="sub-nav__container">
-      <ul class="sub-nav__list">
+      <ul class="sub-nav__list js-sub-nav-list">
         {{#each sub_nav}}
           <li class="sub-nav__item sub-nav__item--{{link}}">
             <a class="sub-nav__link js-sub-nav-link" href="#{{link}}">{{title}}</a>

--- a/src/components/sub_nav/sub_nav_item.hbs
+++ b/src/components/sub_nav/sub_nav_item.hbs
@@ -1,0 +1,5 @@
+<li class="sub-nav__item sub-nav__item--{{id}}">
+  <a class="sub-nav__link js-sub-nav-link" href="#{{id}}">
+    {{title}}
+  </a>
+</li>


### PR DESCRIPTION
The experiences (ttd) link is being added dynamically now and it wasn't getting the active state when the section was scrolled into. This was fixed by moving the `subscribe` and `addClientSideComponents` methods above the scroll-spy code and inside of the conditional.

Completed a TODO which loads dynamic sub nav items in via a handlebars template and allows for dynamic data (id and title).

Changed `#ttd` to `#experiences`. Just a small change but makes things a little nicer.

The sub-nav needs some more refactoring and that is to come soon; I wanted to get this update.

Related: https://github.com/lonelyplanet/destinations-next/pull/610