### PR TITLE
Namespace js-search classname in header component

### DIFF
--- a/lib/helpers/nav_class_names.js
+++ b/lib/helpers/nav_class_names.js
@@ -1,15 +1,15 @@
 module.exports = function(title) {
-	var className = "";
-	
-	if (title === "Destinations") {
-		className = "navigation__item--active";
-	} else if (title === "Search") {
-		className = "js-search";	
-	} else if (title === "Shop") {
-		className = "js-cart-notification";
-	} else if (title === "Sign In") {
-		className = "navigation__item--user";
-	}
-	
-	return className;
+  var className = "";
+
+  if (title === "Destinations") {
+    className = "navigation__item--active";
+  } else if (title === "Search") {
+    className = "js-lp-search";
+  } else if (title === "Shop") {
+    className = "js-cart-notification";
+  } else if (title === "Sign In") {
+    className = "navigation__item--user";
+  }
+
+  return className;
 };

--- a/spec/unit/components/header.spec.js
+++ b/spec/unit/components/header.spec.js
@@ -22,13 +22,13 @@ let html = headerTemplate({
 describe("header", () => {
   it("should render", () => {
     let { isTooBig } = Header.prototype;
-    
+
     // Mock this method
     Header.prototype.isTooBig = () => true;
     let header = new Header({ el: $(html) });
 
     expect(header.$search.hasClass("header__search--fade")).to.be.ok();
-    
+
     // Cleanup
     Header.prototype.isTooBig = isTooBig;
   });
@@ -37,7 +37,7 @@ describe("header", () => {
     let $el = $(html);
     let header = new Header({ el: $el });
 
-    $el.find(".js-search").eq(0).trigger("click");
+    $el.find(".js-lp-search").eq(0).trigger("click");
 
     expect(showSearchCalled).to.be(1);
   });

--- a/src/components/header/header.hbs
+++ b/src/components/header/header.hbs
@@ -13,7 +13,7 @@
         </svg>
       </a>
 
-      <button class="header__search js-search">
+      <button class="header__search js-lp-search">
         <i class="icon-search" aria-hidden="true"></i>
         <span class="header__search-text">Search {{search.title}}</span>
         <span class="header__search-beyond">and beyond</span>
@@ -24,7 +24,7 @@
       </div>
 
       <div class="header__mobile header__mobile--left">
-        <button class="header__mobile-search icon-search-thin js-search">Search</button>
+        <button class="header__mobile-search icon-search-thin js-lp-search">Search</button>
       </div>
 
       <div class="header__mobile">

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -19,8 +19,8 @@ class Header extends Component {
     });
 
     this.events = {
-      "click .js-search": "onSearchClick",
-      "click .js-search .navigation__link": "onSearchClick",
+      "click .js-lp-search": "onSearchClick",
+      "click .js-lp-search .navigation__link": "onSearchClick",
       "click .js-menu": "onMobileMenuClick"
     };
 
@@ -45,12 +45,12 @@ class Header extends Component {
   }
   /**
    * If the search box is too big based on the screen width
-   * @return {Boolean} 
+   * @return {Boolean}
    */
   isTooBig() {
     return this.$search.width() > this.$inner.width() * .42;
   }
-  
+
   onSearchClick(e) {
     e.preventDefault();
 


### PR DESCRIPTION
This has been done to avoid naming conflicts when Rizzo Next is used alongside Rizzo.