### PR TITLE
Add URL slug for sights link

### DIFF
--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -6,7 +6,7 @@
 
     <div class="js-sights-list"></div>
 
-    <a class="sights__more" href="#">
+    <a class="sights__more" href="/{{sights_slug}}/sights">
       See all sights
       <i class="icon-chevron-right" aria-hidden="true"></i>
     </a>


### PR DESCRIPTION
Adds missing `href` for "view more" link.

Related: https://github.com/lonelyplanet/destinations-next/pull/613