### PR TITLE
Fix issues with TTD aka experiences components

### DIFF
--- a/src/components/sights/sights_component.js
+++ b/src/components/sights/sights_component.js
@@ -9,7 +9,7 @@ export default class Sights extends Component {
     this.subscribe();
   }
 
-  @subscribe("ttd.removed", "components");
+  @subscribe("experiences.removed", "components");
   _changeTitle() {
     this.$el.find(".js-sights-heading").toggleClass("sights__heading--large");
   }

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -139,11 +139,15 @@ export default class SubNav extends Component {
 
     this.$el.find(`.sub-nav__item--${component}`).remove();
   }
-  @subscribe("ttd.removed", "components");
+  @subscribe("experiences.removed", "components");
   addSights() {
-    $(this.subNavItem({
-      id: "sights",
-      title: "Sights"
-    })).prependTo(this.$subNavList);
+    if ($(".sights").length) {
+      $(this.subNavItem({
+        id: "sights",
+        title: "Sights"
+      })).prependTo(this.$subNavList);
+    } else {
+      $("#sights").closest(".segment").remove();
+    }
   }
 }

--- a/src/components/things_to_do/things_to_do.js
+++ b/src/components/things_to_do/things_to_do.js
@@ -43,9 +43,9 @@ class ThingsToDo extends Component {
       url: `/api/${window.lp.place.slug}/experiences`
     });
   }
-  @publish("ttd.removed")
+  @publish("experiences.removed")
   nukeIt() {
-    $("#ttd").remove();
+    $("#experiences").remove();
   }
   // TODO: jc this is... smelly
   cardsFetched(cards) {


### PR DESCRIPTION
Update selector from `#ttd` to `#experiences`

- This will fix the issue of the experiences section not being removed if empty.

Fix experiences notifier

- Update ttd to experiences in `subscribe` method to fix sub nav link not being removed
- Inside of `addSights` method, first check if `.sights` exists, if not, remove the closest `.segment` aka its parent