### PR TITLE
Remove static container from narrow header

### DIFF
--- a/sass/typography/_headings_mixins.scss
+++ b/sass/typography/_headings_mixins.scss
@@ -66,7 +66,9 @@
   }
 
   &.is-narrow {
-    @include container-static(10);
+    @include with-layout(static) {
+      max-width: span(10);
+    }
   }
 
   &.has-flexbox {


### PR DESCRIPTION
Replace with `max-width` to fix issue where header can be too wide.

Fixes #323