### PR TITLE
Fix POI callout image

### DIFF
--- a/src/components/poi_callout/poi_callout.js
+++ b/src/components/poi_callout/poi_callout.js
@@ -137,15 +137,6 @@ export default class PoiCalloutComponent extends Component {
    */
   _updatePoiCallout() {
     let poiData = this.pois[this.$activeLink.data("calloutSlug")];
-    let image, src;
-
-    if (poiData.image) {
-      // TODO: Do this on the Ruby side
-      image = poiData.image.replace("http://media.lonelyplanet.com/", "");
-      src = `https://lonelyplanetimages.imgix.net/${image}?w=210&h=95&fit=crop`;
-    } else {
-      src = "";
-    }
 
     this.$callout
       .addClass("is-visible")
@@ -161,7 +152,7 @@ export default class PoiCalloutComponent extends Component {
         name: poiData.name,
         topic: poiData.topic,
         excerpt: poiData.excerpt,
-        image: src
+        image: poiData.image
       }));
   }
 


### PR DESCRIPTION
Now that imgix is being used to set the image, the conditional and `replace` method is no longer needed.

Fixes #332