### PR TITLE
Remove rule for article images with `aligncenter` class

### DIFF
--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -206,11 +206,6 @@
           max-width: 100%;
           width: 100%;
         }
-
-        &.aligncenter {
-          margin-left: auto;
-          margin-right: auto;
-        }
       }
     }
 


### PR DESCRIPTION
This rule causes images to become off-center at viewports less than 840px. It can be removed because it's not doing anything to help.

Fixes #336