### PR TITLE
Use absolute URL for sights link

### DIFF
--- a/src/components/sights/sights.hbs
+++ b/src/components/sights/sights.hbs
@@ -6,7 +6,7 @@
 
     <div class="js-sights-list"></div>
 
-    <a class="sights__more" href="/{{sights_slug}}/sights">
+    <a class="sights__more" href="http://www.lonelyplanet.com/{{sights_slug}}/sights">
       See all sights
       <i class="icon-chevron-right" aria-hidden="true"></i>
     </a>


### PR DESCRIPTION
The "see all sights" link needs to go to `http` instead of `https` which means the link needs to be absolute rather than relative since the new site is forcing `https`.

Fixes lonelyplanet/destinations-next#639