### PR TITLE
Ad Fixes

### DIFF
--- a/src/components/ads/ads.scss
+++ b/src/components/ads/ads.scss
@@ -49,6 +49,8 @@
     height: 12rem;
     margin-left: ($gutter * 2);
     width: 15rem;
+    padding-bottom: 0;
+    padding-top: 0;
   }
 
   &--sponsor-logo-masthead {

--- a/src/components/article/article.js
+++ b/src/components/article/article.js
@@ -433,7 +433,7 @@ export default class ArticleComponent extends Component {
     window.lp.ads.country = article.tealium.article.cd2_Country ? this._slugify(article.tealium.article.cd2_Country) : "";
     window.lp.ads.destination = this._slugify(article.tealium.place.destination);
     window.lp.ads.interest = window.lp.article.interests;
-    window.lp.ads.position = article.articleNumber;
+    window.lp.ads.position = `article-${article.articleNumber}`;
 
     this._updateMetaData(window.lp.article);
   }

--- a/src/components/love_letter/love_letter.hbs
+++ b/src/components/love_letter/love_letter.hbs
@@ -23,7 +23,7 @@
       </div>
     </a>
     {{/if}}
-    <div id="sponsor-logo" class="adunit adunit--sponsor-logo" data-size-mapping="sponsor-logo" data-targeting="{ position: 'love-letter' }"></div>
+    <div id="sponsor-logo-love-letter" class="adunit adunit--sponsor-logo display-none" data-size-mapping="sponsor-logo" data-targeting='{ "position": "love-letter" }'></div>
   </div>
   
 </article>

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -54,7 +54,7 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
           <span class="masthead__button--play__label">Play Video</span>
         </button>
 
-        <div id="sponsor-logo" class="adunit adunit--sponsor-logo-masthead" data-size-mapping="sponsor-logo" data-targeting="{ position: 'masthead' }" style="display: none;"></div>
+        <div id="sponsor-logo-masthead" class="adunit adunit--sponsor-logo-masthead display-none" data-size-mapping="sponsor-logo" data-targeting='{ "position": "masthead" }'></div>
       </div>
     </div>
   </div>

--- a/src/core/ads/ad_manager.js
+++ b/src/core/ads/ad_manager.js
@@ -83,7 +83,9 @@ export default class AdManager {
       topic: config.topic,
       thm: config.adThm,
       ctt: this._slugify(config.continent),
+      continent: this._slugify(config.continent),
       cnty: this._slugify(config.country),
+      country: this._slugify(config.country),
       city: this._slugify(config.city),
       dest: this._slugify(config.destination),
       destination: this._slugify(config.destination)

--- a/src/core/ads/ad_unit.js
+++ b/src/core/ads/ad_unit.js
@@ -22,7 +22,7 @@ export default class AdUnit {
   }
 
   isEmpty() {
-    if (this.$target.css("display") === "none" || !$.trim(this.$target.html())) {
+    if (this.$target.css("display") === "none") {
       return true;
     }
 


### PR DESCRIPTION
Add better targeting names
Revert check for empty ads and simply use display-none class which jQuery.DFP will remove