### PR TITLE
Refactor map pin

### DIFF
--- a/src/components/map/sidebar/item.scss
+++ b/src/components/map/sidebar/item.scss
@@ -1,6 +1,7 @@
 .place {
   background-color: #fff;
   cursor: pointer;
+  font-family: $benton-sans;
   height: 6rem;
   position: relative;
 
@@ -69,17 +70,6 @@
       position: absolute;
       right: 0;
       width: 0;
-    }
-
-    &::after {
-      background-position: .3rem 61%;
-      border-left: .1rem solid #eef1fa;
-      height: ($order-width * .6);
-      position: absolute;
-      right: 1rem;
-      top: 50%;
-      transform: translate(0, -50%);
-      width: 1.7rem;
     }
   }
 
@@ -151,10 +141,41 @@
     }
 
     .pin & {
+      line-height: 1;
       padding-right: $gutter;
       right: 0;
       width: ($item-width-pin - $image-width - $gutter);
       word-spacing: -.1em;
+    }
+  }
+
+  &__icon {
+    .list & {
+      display: none;
+    }
+
+    .pin & {
+      background-position: .3rem 61%;
+      border-left: .1rem solid #eef1fa;
+      height: ($order-width * .6);
+      position: absolute;
+      right: 1rem;
+      top: 50%;
+      transform: translate(0, -50%);
+      width: 1.7rem;
+
+      .icon {
+        color: $color-blue;
+        left: .5rem;
+        margin-top: .1rem;
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+
+        &::before {
+          font-size: 1.2rem;
+        }
+      }
     }
   }
 }

--- a/src/components/map/views/item.jsx
+++ b/src/components/map/views/item.jsx
@@ -14,9 +14,9 @@ export default class ItemView extends React.Component {
         imgStyle;
 
     if (item.onMap) {
-      classString += "pin icon icon--chevron-right";
+      classString += "pin";
       if (title.length > 23) {
-        title = title.substr(0, 22) + "...";
+        title = title.substr(0, 22) + "…";
       }
     } else {
       classString += "list";
@@ -24,7 +24,7 @@ export default class ItemView extends React.Component {
         classString += " is-hovered";
       }
       if (title.length > 36) {
-        title = title.substr(0, 35) + "...";
+        title = title.substr(0, 35) + "…";
       }
     }
     if (item.geo.properties.image) {
@@ -51,6 +51,9 @@ export default class ItemView extends React.Component {
         <div className="place__text">
           <div className="title">{title}</div>
           {subtitle}
+        </div>
+        <div className="place__icon">
+          <i className="icon icon-chevron-right" aria-hidden="true"></i>
         </div>
       </div>
     );


### PR DESCRIPTION
The current implementation had `icon` classnames on the pin element itself, which caused some issues:

1. It added the icon font as the `font-family` for the pin which means that pin text was not using Benton
2. It added a background image to the pin (this was being overridden in CSS)

The solution was to create an icon element and apply the icon styles to that element.

Fixes #343