### PR TITLE
Remove wait for transition to focus search input

### DIFF
--- a/src/components/search/search_component.js
+++ b/src/components/search/search_component.js
@@ -93,10 +93,7 @@ class SearchComponent extends Component {
       this.$el.addClass(SearchComponent.className + "--visible");
     }, 10);
 
-    return waitForTransition(this.$el, { fallbackTime: 100 })
-      .then(() => {
-        this.$input.focus();
-      });
+    this.$input.focus();
   }
 
   hide() {


### PR DESCRIPTION
I have not been able to figure out why, but on iOS, the search input will not focus when it's inside of the `waitForTransition` method. Removing the method seems to have no negative effects on desktop or mobile, but the input now gets focused on mobile.

In my debugging, the `waitForTransition` method is working properly because I was able to `console.log` inside of it. I've tried `blur()`ing the button before adding `focus()` to the input, but that didn't work either.

Fixes #335