### PR TITLE
Fix browser history bug with map

### DIFF
--- a/spec/unit/components/map.spec.js
+++ b/spec/unit/components/map.spec.js
@@ -12,7 +12,7 @@ let MapComponent = Injector({
   "history": {
     createHistory: function() {
       return {
-        pushState: pushState
+        push: pushState
       };
     }
   },
@@ -36,18 +36,18 @@ window.lp = {
 describe("map component", () => {
   it("should open, close and adjust the url", () => {
     let map = new MapComponent();
-    
+
     sinon.stub(map, "isOnMap")
       .returns(false);
 
     map.open();
 
     expect(pushState.calledOnce).to.be.ok();
-    expect(pushState.getCall(0).args[1].indexOf("/map")).to.not.be(-1);
+    expect(pushState.getCall(0).args[0].pathname.indexOf("/map")).to.not.be(-1);
 
     map.close();
 
-    expect(pushState.getCall(1).args[1].indexOf("/map")).to.be(-1);
+    expect(pushState.getCall(1).args[0].pathname.indexOf("/map")).to.be(-1);
 
     pushState.reset();
   });

--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -3,8 +3,11 @@ import React from "react";
 import MainView from "./views/main.jsx";
 import MapActions from "./actions";
 import Arkham from "../../core/arkham";
+import { createHistory } from "history";
 import $ from "jquery";
 import MapApi from "./map_api";
+
+let history = createHistory();
 
 class MapComponent extends Component {
 
@@ -52,7 +55,11 @@ class MapComponent extends Component {
 
     if (!this.isOnMap()) {
       let pathname = this.getMapPath();
-      history.pushState({ isOnMap: true }, null, `${pathname}map`);
+
+      history.push({
+        pathname: `${pathname}map`,
+        state: { isOnMap: true }
+      });
     }
   }
 
@@ -75,7 +82,11 @@ class MapComponent extends Component {
     this.destroyMap();
 
     let path = window.location.pathname.replace(/\/map\/?$/, "");
-    history.pushState({ isOnMap: false }, null, `${path}`);
+
+    history.push({
+      pathname: `${path}`,
+      state: { isOnMap: false }
+    });
   }
 
   onKeyup(e) {


### PR DESCRIPTION
Fixes lonelyplanet/destinations-next#455

Added a state object when using `pushState` and then used the `window.onpopstate` method to check the state.

Removed the `createHistory` module import. I'm not sure why that was being used instead of the native `window.history`. The `createHistory` module seemed to mess up the value of the state when it was updated with `pushState`. It would change it from a boolean to a hashed string (something like `{isOnMap: "xY9ds"}`) which would break functionality.