### PR TITLE
Update clearfix

### DIFF
--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -1,17 +1,11 @@
 
 /// A simple clearfix helper
 @mixin clearfix {
-  &::before,
-  &::after {
-    content: "";
-    display: table;
-  }
-
   &::after {
     clear: both;
+    content: " ";
+    display: table;
   }
-
-  zoom: 1;
 }
 
 /// Set up a media query passing a value to use for min width


### PR DESCRIPTION
- `::before` and `zoom` can be removed because they're for IE 6 and 7
- `block` instead of `table` for `display` so that margins collapse
- space in `content` for Opera