### PR TITLE
Masthead updates

### DIFF
--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -52,44 +52,17 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     box-sizing: content-box;
     display: flex;
     justify-content: center;
-    left: ($gutter * .5);
-    padding-left: ($gutter * .5);
-    padding-right: ($gutter * .5);
     position: absolute;
-    right: ($gutter * .5);
     top: 0;
+    width: 100%;
     z-index: z("middle");
-
-    @media (min-width: $min-480) {
-      left: $gutter;
-      padding-left: $gutter;
-      padding-right: $gutter;
-      right: $gutter;
-    }
-
-    @media (min-width: $min-720) {
-      top: $header-height-mobile;
-    }
-
-    @media (min-width: $min-1080) {
-      left: ($gutter * 2);
-      padding-left: ($gutter * 4);
-      padding-right: ($gutter * 4);
-      right: ($gutter * 2);
-    }
-
-    @media (min-width: $min-1290) {
-      left: 0;
-      margin-left: auto;
-      margin-right: auto;
-      max-width: 90%;
-      right: 0;
-    }
   }
 
   &__text-wrap--pull-up {
-    @media (max-height: 699px) {
-      top: -4.5rem;
+    .masthead__text {
+      @media (max-height: 699px) {
+        margin-top: -4.5rem;
+      }
     }
   }
 
@@ -119,17 +92,19 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
   }
 
   &__text {
+    @include container-padded();
+    text-align: center;
     width: 100%;
+
+    @media (min-width: $min-720) {
+      margin-top: $header-height-mobile;
+    }
   }
 
   .no-flexbox &__text {
     display: table;
     height: 100%;
     width: 100%;
-  }
-
-  &__container {
-    text-align: center;
   }
 
   .no-flexbox &__container {

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -24,8 +24,8 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
   {{/if}}
 
   <div class="masthead__text-wrap">
-    <div class="masthead__text {{#if masthead.first}}masthead__text--visible{{/if}}">
-      <div class="masthead__container">
+    <div class="masthead__text{{#if masthead.first}} masthead__text--visible{{/if}}">
+      {{#if masthead.parent}}
         <div class="masthead__breadcrumb">
           {{#if masthead.grandparent}}
             <a href="{{masthead.grandparent.slug}}">{{masthead.grandparent.place}}</a>
@@ -33,31 +33,34 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
           {{/if}}
           <a href="{{masthead.parent.slug}}">{{masthead.parent.place}}</a>
         </div>
-        <h1 class="masthead__title js-masthead-title">{{masthead.title}}</h1>
+      {{/if}}
 
-        {{#if masthead.images}}
-          <div class="masthead__straplines">
-            {{#each masthead.images}}
-              <div class="masthead__strapline{{#if @first}} masthead__strapline--visible{{/if}}">{{strapline}}</div>
-            {{/each}}
-          </div>
-        {{/if}}
+      <h1 class="masthead__title js-masthead-title">
+        {{masthead.title}}
+      </h1>
 
-        {{#if top_places}}
-          <button class="masthead__button js-top-places">
-            {{masthead_button_types}} <i class="icon-chevron-down" aria-hidden="true"></i>
-          </button>
-        {{/if}}
+      {{#if masthead.images}}
+        <div class="masthead__straplines">
+          {{#each masthead.images}}
+            <div class="masthead__strapline{{#if @first}} masthead__strapline--visible{{/if}}">{{strapline}}</div>
+          {{/each}}
+        </div>
+      {{/if}}
 
-        <button class="masthead__button--play js-play-video" hidden>
-          <i class="masthead__button--play__icon icon-play3" aria-hidden="true"></i>
-          <span class="masthead__button--play__label">Play Video</span>
+      {{#if top_places}}
+        <button class="masthead__button js-top-places">
+          {{masthead_button_types}} <i class="icon-chevron-down" aria-hidden="true"></i>
         </button>
-      </div>
+      {{/if}}
+
+      <button class="masthead__button--play js-play-video" hidden>
+        <i class="masthead__button--play__icon icon-play3" aria-hidden="true"></i>
+        <span class="masthead__button--play__label">Play Video</span>
+      </button>
     </div>
   </div>
 
-  <div class="masthead__ad">
+  <div class="masthead__ad js-masthead-ad">
     <div class="adunit adunit--sponsor-logo-masthead display-none"
       id="sponsor-logo-masthead"
       data-size-mapping="sponsor-logo"
@@ -68,6 +71,7 @@ found at https://accounts.brightcove.com/en/terms-and-conditions/.
   {{#if is_continent}}
     {{> "components/masthead/masthead_nav" }}
   {{/if}}
+
 
   {{#if top_places}}
     {{> "components/top_places/top_places" }}

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -51,6 +51,7 @@ export default class MastheadComponent extends Component {
     this.listenTo(this.slideshow, "image.changed", this.updateStrapline);
 
     fitText(this.$el.find(".js-masthead-title"), {
+      fontSizes: [ 56, 60, 80, 120 ],
       minFontSize: 56
     });
 

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -60,9 +60,15 @@ export default class MastheadComponent extends Component {
   @subscribe("ad.loaded", "ads");
   mastheadAdLoaded(data) {
     if (data.id === "sponsor-logo-masthead") {
-      if ($("#" + data.id).hasClass("display-block")) {
+      let $mastheadAd = this.$el.find("#" + data.id);
+
+      if ($mastheadAd.hasClass("display-block")) {
         this.$el.find(".masthead__text-wrap")
           .addClass("masthead__text-wrap--pull-up");
+      } else {
+        $mastheadAd
+          .closest(".js-masthead-ad")
+          .remove();
       }
     }
   }


### PR DESCRIPTION
Simplifies the masthead CSS a bit, adds a conditional around the breadcrumbs element to hide if there's no content and removes the sponsor ad if there's no content.

Also fixes #390.