### PR TITLE
Setup cookie compliance

### DIFF
--- a/src/components/alert/alert.hbs
+++ b/src/components/alert/alert.hbs
@@ -1,7 +1,7 @@
 <section class="alert is-visible">
-  <div class="alert__container alert__container--{{ alert_type }}">
+  <div class="alert__container alert__container--{{ alert.type }}">
     <div class="alert__inner">
-      {{ alert_text }} <a class="js-alert-link alert__inner--link" href="#">{{ alert_link_text }}</a>.
+      {{ alert.text }} <a class="js-alert-link alert__inner--link" href="{{alert.link}}">{{ alert.link_text }}</a>.
       <button class="alert__close icon-close-small js-close">Close</button>
     </div>
   </div>

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -5,33 +5,42 @@ import waitForTransition from "../../core/utils/waitForTransition";
 require("./_alert.scss");
 
 class Alert extends Component {
-
-  initialize() {
+  get cookieName() {
+    return "dn-hide-banner";
+  }
+  /**
+   * Create a new alert for the top of the page
+   * @param  {[object]} options.alert An alert object
+   * @param  {[string]} options.alert.type Type of alert
+   * @param  {[string]} options.alert.text Text of the alert
+   * @param  {[string]} options.alert.link_text String of the link
+   * @return {[type]}               [description]
+   */
+  initialize({ alert, callback }) {
     this.cookieUtil = new CookieUtil();
-    if (this.cookieUtil.getCookie("dn-opt-in")) {
+    if (this.cookieUtil.getCookie(this.cookieName)) {
       return;
     }
+    console.log(this.$el);
 
-    this.alert = {
-      alert_type: "default",
-      alert_text: "Return to old experience?",
-      alert_link_text: "Leave beta"
-    };
+    this.alert = alert;
+    this.callback = callback;
 
     this.template = require("./alert.hbs");
-    this.$el.prepend($(this.template(this.alert)));
+    let html = this.template({ alert: this.alert });
+    
+    this.$el.prepend(html);
     this.$alert = this.$el.find(".alert");
     this.$alert.find(".alert__inner").addClass("is-visible");
 
     this.events = {
       "click .js-close": "hideAlert",
-      "click .js-alert-link": "removeCookies"
+      "click .js-alert-link": "linkClicked"
     };
-
   }
 
   hideAlert() {
-    this.cookieUtil.setCookie("dn-opt-in", "true", 30);
+    this.cookieUtil.setCookie(this.cookieName, "true", 30);
     this.$alert.removeClass("is-visible");
     return waitForTransition(this.$alert, { fallbackTime: 1000 })
       .then(() => {
@@ -39,11 +48,9 @@ class Alert extends Component {
       });
   }
 
-  removeCookies(e) {
+  linkClicked(e) {
     e.preventDefault();
-    this.cookieUtil.removeCookie("_v");
-    this.cookieUtil.removeCookie("destinations-next-cookie");
-    location.reload();
+    this.callback && this.callback();
   }
 }
 

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -21,7 +21,6 @@ class Alert extends Component {
     if (this.cookieUtil.getCookie(this.cookieName)) {
       return;
     }
-    console.log(this.$el);
 
     this.alert = alert;
     this.callback = callback;
@@ -48,8 +47,7 @@ class Alert extends Component {
       });
   }
 
-  linkClicked(e) {
-    e.preventDefault();
+  linkClicked() {
     this.callback && this.callback();
   }
 }

--- a/src/components/map/alert.scss
+++ b/src/components/map/alert.scss
@@ -1,4 +1,4 @@
-.alert {
+.map-alert {
   background-color: #333;
   border: .1rem solid #fff;
   color: #fff;

--- a/src/components/map/views/alert.jsx
+++ b/src/components/map/views/alert.jsx
@@ -6,7 +6,7 @@ import React from "react";
 export default class AlertView extends React.Component {
 
   render() {
-    let classString = "alert",
+    let classString = "map-alert",
         message = "";
 
     if (this.props.error) {


### PR DESCRIPTION
Closes lonelyplanet/destinations-next#694.
Make alert more re-usable.
Turn on alert for cookie compliance in EU.
Change map-alert class for better specificity.