### PR TITLE
Remove the resrc.it url from sights component

### DIFF
--- a/src/components/sights/sights_item.hbs
+++ b/src/components/sights/sights_item.hbs
@@ -1,6 +1,6 @@
 <a class="sights__item" href="/{{slug}}">
   {{#if img_url}}
-    <img src="http://images-resrc.staticlp.com/O=60/S=W80,H60/{{img_url}}" alt="">
+    <img src="{{img_url}}" alt="">
   {{else}}
     <div class="sights__image topic__image topic__image--sight"></div>
   {{/if}}


### PR DESCRIPTION
A change in DN will include full URLs for these images, resulting in broken images. Also, we should be switching over to imgix anyway.