### PR TITLE
set negative z-index for mobile-navigation before initialization

### DIFF
--- a/src/components/navigation/_mobile-navigation.scss
+++ b/src/components/navigation/_mobile-navigation.scss
@@ -22,6 +22,10 @@
     transition: transform ($animation-speed / 2), opacity ($animation-speed / 2);
   }
 
+  &--hidden {
+    z-index: -20;
+  }
+
   &--visible,
   &--visible &__list {
     opacity: 1;

--- a/src/components/navigation/_mobile-navigation.scss
+++ b/src/components/navigation/_mobile-navigation.scss
@@ -23,7 +23,7 @@
   }
 
   &--hidden {
-    z-index: -20;
+    z-index: z("below");
   }
 
   &--visible,

--- a/src/components/navigation/navigation.hbs
+++ b/src/components/navigation/navigation.hbs
@@ -36,7 +36,7 @@
     {{/each}}
   </ul>
 
-  <nav class="mobile-navigation">
+  <nav class="mobile-navigation mobile-navigation--hidden">
     <button class="mobile-navigation__close icon-close-small js-close">Close</button>
 
     <ul class="mobile-navigation__list">

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -42,6 +42,7 @@ class NavigationComponent extends Component {
 
     this.name = "navigation";
     this.$mobileNavigation = this.$el.find(".mobile-navigation").detach();
+    this.$mobileNavigation.removeClass("mobile-navigation--hidden");
     this.$mobileNavigation.on("click", ".js-close", this._clickNav.bind(this));
     this.$mobileNavigation.on("click", ".js-nav-item", this._handleClick.bind(this));
 


### PR DESCRIPTION
Ravi reported "On the homepage, with the new header, the Shop link doesn't appear to be working".
This is because mobile-navigation element has `z-index: 10000` and before it's detached it covers `shop` and `sing in` buttons.