### PR TITLE
Check for related articles first

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -157,6 +157,7 @@ export default class ArticleComponent extends Component {
         title: this.nextArticle.title
       }
     };
+
     this._loadStickyFooter();
   }
 

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -116,40 +116,48 @@ export default class ArticleComponent extends Component {
     });
 
     firstArticle.fetch().then(() => {
+      let relatedArticles = firstArticle.get("related_articles").articles;
+
       this.articles.set(this.$el[0], firstArticle);
-      this._setInitialListOfArticles(firstArticle.get("related_articles").articles);
       this._setInitialCallouts(firstArticle.get("content").callouts);
 
-      // Add the first article to the list of viewed articles
-      this.viewedArticles.push({
-        slug: this.$el.data("slug"),
-        title: this.$el.data("title"),
-        scroll: {
-          articleOffsetTop: this.$el.offset().top,
-          amountNeededToScroll: this._getAmountNeededToScroll()
-        },
-        next: {
-          slug: this.nextArticle.slug,
-          title: this.nextArticle.title
-        }
-      });
-
-      this.$el.attr("id", this._createIdForArticle(this.$el.data("slug")));
-
-      this.state = {
-        current: {
-          title: this.$el.data("title")
-        },
-        next: {
-          slug: this.nextArticle.slug,
-          title: this.nextArticle.title
-        }
-      };
-
-      this._loadStickyFooter();
+      if (relatedArticles.length) {
+        this._setUpRelatedArticles(relatedArticles);
+      }
     }, () => {
       rizzo.logger.error(`Unable to fetch ${window.location.pathname}.json`);
     });
+  }
+
+  _setUpRelatedArticles(articles) {
+    this._setInitialListOfArticles(articles);
+
+    // Add the first article to the list of viewed articles
+    this.viewedArticles.push({
+      slug: this.$el.data("slug"),
+      title: this.$el.data("title"),
+      scroll: {
+        articleOffsetTop: this.$el.offset().top,
+        amountNeededToScroll: this._getAmountNeededToScroll()
+      },
+      next: {
+        slug: this.nextArticle.slug,
+        title: this.nextArticle.title
+      }
+    });
+
+    this.$el.attr("id", this._createIdForArticle(this.$el.data("slug")));
+
+    this.state = {
+      current: {
+        title: this.$el.data("title")
+      },
+      next: {
+        slug: this.nextArticle.slug,
+        title: this.nextArticle.title
+      }
+    };
+    this._loadStickyFooter();
   }
 
   _setInitialCallouts(callouts) {

--- a/src/components/sticky_footer/sticky_footer.scss
+++ b/src/components/sticky_footer/sticky_footer.scss
@@ -21,7 +21,7 @@ $lp-sticky-footer-height: 7.6rem;
     transform: translateY(0);
     transition: transform $animation-speed ease-in-out;
     width: 100%;
-    z-index: z("header");
+    z-index: z("global-header");
   }
 
   &.off-screen {


### PR DESCRIPTION
Fixes lonelyplanet/destinations-next#743.

Related to the sticky footer, there was a JS error when there are no related articles. This fix conditionally loads the sticky footer and other related code for infinite scrolling.

Also, fix a z-index bug on the sticky footer.