### PR TITLE
Add CSS breakpoint values to JS

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -10,6 +10,7 @@ import ArticleModel from "./article_model";
 import rizzo from "../../rizzo";
 import subscribe from "../../core/decorators/subscribe";
 import matchMedia from "../../core/utils/matchMedia";
+import breakpoints from "../../core/utils/breakpoints";
 import StickyFooterComponent from "../sticky_footer";
 
 export default class ArticleComponent extends Component {
@@ -91,7 +92,7 @@ export default class ArticleComponent extends Component {
       this.state
     );
 
-    matchMedia("(min-width: 720px)", (query) => {
+    matchMedia(`(min-width: ${breakpoints.min["720"]})`, (query) => {
       if (query.matches) {
         this.stickyFooterComponent.attach();
         this.stickyFooterComponent.scroll();

--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -4,7 +4,8 @@ import ImageGallery from "../image_gallery";
 import PoiCallout from "../poi_callout";
 import moment from "moment";
 import matchMedia from "../../core/utils/matchMedia";
-import rizzo from "../../rizzo"; 
+import breakpoints from "../../core/utils/breakpoints";
+import rizzo from "../../rizzo";
 
 /**
  * Enhances the body of articles with a gallery and more
@@ -21,7 +22,7 @@ export default class ArticleBodyComponent extends Component {
     });
 
     if (this.poiData) {
-      matchMedia("(min-width: 1200px)", (query) => {
+      matchMedia(`(min-width: ${breakpoints.min["1200"]})`, (query) => {
         if (query.matches) {
           this.loadPoiCallout(this.poiData);
         } else {

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -6,6 +6,7 @@ import NavigationActions from "./navigation_actions";
 import NavigationState from "./navigation_state";
 import subscribe from "../../core/decorators/subscribe";
 import matchMedia from "../../core/utils/matchMedia";
+import breakpoints from "../../core/utils/breakpoints";
 
 let userPanelTemplate = require("./user_panel.hbs"),
     userAvatarTemplate = require("./user_avatar.hbs"),
@@ -27,7 +28,7 @@ class NavigationComponent extends Component {
       label: `${this.state.cartItemCount} ${notificationLabel} in your cart`
     });
 
-    matchMedia("(min-width: 720px)", (query) => {
+    matchMedia(`(min-width: ${breakpoints.min["720"]})`, (query) => {
       if (query.matches) {
         this.notification.$el.find(".js-notification-badge")
           .removeClass("notification-badge--shop-inline")
@@ -66,8 +67,8 @@ class NavigationComponent extends Component {
   _handleClick(e) {
     let $target = $(e.currentTarget);
 
-    $target.hasClass("navigation__item") ? this._handleSubNav($target[0]) : this._handleMobileSubNav($target[0]); 
-    
+    $target.hasClass("navigation__item") ? this._handleSubNav($target[0]) : this._handleMobileSubNav($target[0]);
+
     if (
       $target.find(".mobile-sub-navigation").length &&
       !$(e.target).hasClass("sub-navigation__link")

--- a/src/core/utils/breakpoints.js
+++ b/src/core/utils/breakpoints.js
@@ -1,0 +1,44 @@
+// Usage
+// import breakpoints from "./core/utils/breakpoints";
+// let breakpoint = breakpoints.min["1410"];
+
+let multiplier = 1 / 16,
+    value = "em";
+
+export default {
+  "min": {
+    "1410": (1410 * multiplier) + value,
+    "1350": (1350 * multiplier) + value,
+    "1290": (1290 * multiplier) + value,
+    "1200": (1200 * multiplier) + value,
+    "1080": (1080 * multiplier) + value,
+    "1024": (1024 * multiplier) + value,
+    "960": (960 * multiplier) + value,
+    "840": (840 * multiplier) + value,
+    "768": (768 * multiplier) + value,
+    "720": (720 * multiplier) + value,
+    "600": (600 * multiplier) + value,
+    "560": (560 * multiplier) + value,
+    "480": (480 * multiplier) + value,
+    "360": (360 * multiplier) + value,
+    "320": (320 * multiplier) + value
+  },
+  "max": {
+    "1530": (1530 * multiplier) + value,
+    "1410": (1409 * multiplier) + value,
+    "1350": (1349 * multiplier) + value,
+    "1290": (1289 * multiplier) + value,
+    "1200": (1199 * multiplier) + value,
+    "1080": (1079 * multiplier) + value,
+    "1024": (1023 * multiplier) + value,
+    "960": (959 * multiplier) + value,
+    "840": (839 * multiplier) + value,
+    "768": (767 * multiplier) + value,
+    "720": (719 * multiplier) + value,
+    "600": (599 * multiplier) + value,
+    "560": (559 * multiplier) + value,
+    "480": (479 * multiplier) + value,
+    "360": (359 * multiplier) + value,
+    "320": (319 * multiplier) + value
+  }
+};


### PR DESCRIPTION
It's not perfect, but this PR duplicates the breakpoint variables defined [here](https://github.com/lonelyplanet/rizzo-next/blob/tc-js-breakpoints/sass/_variables.scss) for use in JS with `matchMedia`.