### PR TITLE
Recalculate amount to scroll for sticky footer

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -17,6 +17,8 @@ export default class ArticleComponent extends Component {
   initialize() {
     this.canUseScrollFeature = window.history && window.history.replaceState;
 
+    this.subscribe();
+
     this._resetWindowScrollPosition();
 
     this.$document = $(document);
@@ -24,6 +26,7 @@ export default class ArticleComponent extends Component {
 
     this.isNextArticleLoading = false;
     this.howManyArticlesHaveLoaded = 1;
+    this.maxAdTimeout = 500;
 
     this.template = require("./article.hbs");
     this.loader = require("./article-loading.hbs");
@@ -32,16 +35,9 @@ export default class ArticleComponent extends Component {
     this.articles = new Map();
     this.viewedArticles = [];
     this.listOfArticles = [];
-
     this.state = {};
-    this.maxAdTimeout = 500;
 
     this._setFirstArticle();
-    this.subscribe();
-
-    this.stickyFooterComponent = new StickyFooterComponent({
-      el: $(".lp-sticky-footer")
-    });
   }
 
   @subscribe("ad.loaded", "ads");
@@ -89,6 +85,12 @@ export default class ArticleComponent extends Component {
     return string.toLowerCase().replace(" ", "-");
   }
 
+  _createStickyFooter() {
+    this.stickyFooterComponent = new StickyFooterComponent({
+      el: $(".lp-sticky-footer")
+    });
+  }
+
   _loadStickyFooter() {
     this.stickyFooterComponent.update(
       this.$el.offset().top,
@@ -112,7 +114,7 @@ export default class ArticleComponent extends Component {
   _setFirstArticle() {
     this.$activeArticle = this.$el.addClass("is-active");
 
-    this.socialShare = new SocialShareComponent({
+    this.socialShareComponent = new SocialShareComponent({
       el: this.$el.find(".js-action-sheet")
     });
 
@@ -127,16 +129,18 @@ export default class ArticleComponent extends Component {
       this._setInitialCallouts(firstArticle.get("content").callouts);
 
       if (relatedArticles.length) {
-        this._setUpRelatedArticles(relatedArticles);
+        this.$el.attr("id", this._createIdForArticle(this.$el.data("slug")));
+        this._setInitialListOfArticles(relatedArticles);
+        this._updateFirstArticle();
+        this._createStickyFooter();
+        this._loadStickyFooter();
       }
     }, () => {
       rizzo.logger.error(`Unable to fetch ${window.location.pathname}.json`);
     });
   }
 
-  _setUpRelatedArticles(articles) {
-    this._setInitialListOfArticles(articles);
-
+  _updateFirstArticle() {
     // Add the first article to the list of viewed articles
     this.viewedArticles.push({
       slug: this.$el.data("slug"),
@@ -151,8 +155,6 @@ export default class ArticleComponent extends Component {
       }
     });
 
-    this.$el.attr("id", this._createIdForArticle(this.$el.data("slug")));
-
     this.state = {
       current: {
         title: this.$el.data("title")
@@ -162,8 +164,6 @@ export default class ArticleComponent extends Component {
         title: this.nextArticle.title
       }
     };
-
-    this._loadStickyFooter();
   }
 
   _setInitialCallouts(callouts) {
@@ -201,6 +201,7 @@ export default class ArticleComponent extends Component {
    */
   _scrollToNextArticle(offsetDifference = 0) {
     let shouldGetNextArticle = false;
+    let hasRecalculatedStickyFooter = false;
 
     this.$window.on("scroll.article", debounce(() => {
       shouldGetNextArticle = this._shouldGetNextArticle(offsetDifference) &&
@@ -213,7 +214,13 @@ export default class ArticleComponent extends Component {
 
       this._setActiveArticle();
       this._checkIfHistoryShouldBeUpdated();
-    }, 10));
+
+      if (!hasRecalculatedStickyFooter) {
+        hasRecalculatedStickyFooter = true;
+        this.stickyFooterComponent.recalculate(this._getAmountNeededToScroll());
+        this.viewedArticles[this.howManyArticlesHaveLoaded - 1].scroll.amountNeededToScroll = this._getAmountNeededToScroll();
+      }
+    }, 100));
   }
 
   _setActiveArticle() {
@@ -242,7 +249,7 @@ export default class ArticleComponent extends Component {
    */
   _getAmountNeededToScroll() {
     let roomToScroll = this._getRoomToScroll(),
-        amountToScrollPastEndOfArticle = 100;
+        amountToScrollPastEndOfArticle = 0;
 
     return roomToScroll - amountToScrollPastEndOfArticle;
   }
@@ -376,7 +383,7 @@ export default class ArticleComponent extends Component {
       poiData: model.get("content").callouts
     });
 
-    this.socialShare = new SocialShareComponent({
+    this.socialShareComponent = new SocialShareComponent({
       el: this.$newArticle.find(".js-action-sheet")
     });
 

--- a/src/components/sticky_footer/sticky_footer.js
+++ b/src/components/sticky_footer/sticky_footer.js
@@ -23,6 +23,7 @@ class StickyFooterComponent extends Component {
     this.nextItem = ".js-lp-sticky-footer-next-item";
     this.nextItemClicked = false;
     this.lastScrollTop = 0;
+    this.isHidden = true;
 
     this.events = {
       ["click " + this.nextItem]: "_goToNextItem"
@@ -46,15 +47,21 @@ class StickyFooterComponent extends Component {
           this.progressComponent.fill();
         }
 
-        this.hide();
+        if (!this.isHidden) {
+          this.hide();
+        }
 
         return waitForTransition(this.$el, { fallbackTime: this.transitionSpeed }).then(() => {
           this.progressComponent.reset();
         });
       } else if (this.$window.scrollTop() >= this.articleOffsetTop) {
-        this.show();
+        if (this.isHidden) {
+          this.show();
+        }
       } else {
-        this.hide();
+        if (!this.isHidden) {
+          this.hide();
+        }
       }
 
       this.progressComponent.update((this.$window.scrollTop() - this.articleOffsetTop) / (this.amountNeededToScroll - this.articleOffsetTop) * 100);
@@ -76,11 +83,19 @@ class StickyFooterComponent extends Component {
     this._setContent(state);
   }
 
+  recalculate(amountNeededToScroll) {
+    this.amountNeededToScroll = amountNeededToScroll;
+  }
+
   show() {
+    this.isHidden = false;
+
     this.$el.removeClass(this.offScreenClassName);
   }
 
   hide() {
+    this.isHidden = true;
+
     this.$el.addClass(this.offScreenClassName);
   }
 


### PR DESCRIPTION
Fixes lonelyplanet/destinations-next#746

The problem was that the amount to scroll was incorrect (too small) when an article has images that are enlarged. The initial amount to scroll is calculated before the images load and when enlarged, the images increase the amount to scroll. The solution was to recalculate the amount to scroll once during the scroll event.

Also, for the sticky footer component, a state variable `isHidden` was added to improve performance a bit; now it only checks once to `show` or `hide`.

Lastly, the debounce was increased from `10` to `100` to improve performance.