### PR TITLE
Simplify and fix underline-link mixin

### DIFF
--- a/sass/typography/_links_mixins.scss
+++ b/sass/typography/_links_mixins.scss
@@ -59,134 +59,62 @@
 
 /// Provides the underline for the `underlined-link` mixin
 /// @param {Color} $color [$color-blue] - Color of the underline, usually the same as the text color
-/// @param {Color} $background-color [#fff] Background color of the underline, usually the same color as the page; used for underline styles not solid
-/// @param {Dimension} $weight [.1rem] - Width of the underline
-/// @param {Dimension} $offset [.2rem] - Amount of padding above the underline
-/// @param {String} $style [solid] The underline style can be solid, dashed or dotted
+/// @param {Dimension} $offset [2px] - Amount of padding above the underline
+/// @param {Dimension} $weight [1px] - Width of the underline
 @mixin underline(
   $color: $color-blue,
-  $background-color: #fff,
-  $weight: .1rem,
-  $offset: .2rem,
-  $style: solid
+  $offset: 2px,
+  $weight: 1px
 ) {
-  $underline: linear-gradient(to top, transparent, transparent $offset, $color $offset, $color ($offset + $weight), transparent ($offset + $weight));
-
-  @if $style == solid {
-    background-image: $underline;
-  }
-
-  @if $style == dashed {
-    background-image: repeating-linear-gradient(
-      to right,
-      rgba($background-color, 0),
-      rgba($background-color, 0) .3rem,
-      $background-color .3rem,
-      $background-color .6rem), $underline;
-  }
-
-  @if $style == dotted {
-    background-image: repeating-linear-gradient(
-      to right,
-      rgba($background-color, 0),
-      rgba($background-color, 0) .1rem,
-      $background-color .1rem,
-      $background-color .2rem), $underline;
-  }
+  background-image: linear-gradient(
+    to top,
+    transparent,
+    transparent $offset,
+    $color $offset,
+    $color ($offset + $weight),
+    transparent ($offset + $weight)
+  );
 }
 
 /// Creates a nicely underlined hyperlink
 /// @param {Color} $link-color [$color-blue] Link color
 /// @param {Color} $link-color-active [$color-blue + 30] Link color for hover, active and focus states
 /// @param {Color} $background-color [#fff] Background color of the link, usually the same color as the page
-/// @param {Color} $background-color-active [#fff] Background color for hover, active and focus states
-/// @param {String} $underline-style [solid] The underline style can be solid or dashed
 /// @param {Boolean} $breaking-underlines [true] If the underline should "break" as it passes thru a descender
 @mixin underlined-link(
   $link-color: $color-blue,
   $link-color-active: $color-blue + 30,
+  $underline-offset: 2px,
   $background-color: #fff,
-  $background-color-active: #fff,
-  $underline-offset: .2rem,
-  $underline-style: solid,
   $breaking-underlines: true
 ) {
-  $transition: .2s ease;
-
-  @include underline(
-    $color: rgba($link-color, .4),
-    $background-color: $background-color,
-    $offset: $underline-offset,
-    $style: $underline-style
-  );
-
+  @include underline(rgba($link-color, .4), $underline-offset);
   color: $link-color;
   position: relative;
   text-decoration: none;
-
-  @if $background-color-active != $background-color {
-    transition: background-color $transition, color $transition, text-shadow $transition;
-  } @else {
-    transition: color $transition;
-  }
+  transition: color 200ms ease;
 
   @if $breaking-underlines {
-    text-shadow: -.1rem -.1rem 0 $background-color,
-      .1rem -.1rem 0 $background-color,
-      -.1rem .1rem 0 $background-color,
-      .1rem .1rem 0 $background-color;
+    text-shadow: -1px -1px 0 $background-color,
+      1px -1px 0 $background-color,
+      -1px 1px 0 $background-color,
+      1px 1px 0 $background-color;
   }
 
-  @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-    @include underline(
-      $color: $link-color,
-      $background-color: $background-color,
-      $weight: .05,
-      $offset: $underline-offset,
-      $style: $underline-style
-    );
-  }
+  // @TODO Figure out why these styles don't work
+  // @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+  //   @include underline(rgba($link-color, .4), $underline-offset, .5);
+  // }
 
   &:hover,
   &:active,
-  &:focus,
-  &.is-active {
+  &:focus {
+    @include underline(rgba($link-color-active, .4), $underline-offset);
     color: $link-color-active;
 
-    @if $underline-style == solid {
-      @include underline(
-        $color: rgba($link-color-active, .4),
-        $offset: $underline-offset
-      );
-    }
-
-    @if $underline-style == dashed or $underline-style == dotted {
-      background-image: none;
-    }
-
-    @if $background-color-active != $background-color {
-      background-color: $background-color-active;
-    }
-
-    @if $breaking-underlines && $background-color-active != $background-color {
-      text-shadow: -.1rem -.1rem 0 $background-color-active,
-        .1rem -.1rem 0 $background-color-active,
-        -.1rem .1rem 0 $background-color-active,
-        .1rem .1rem 0 $background-color-active;
-    }
-
-    @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
-      @if $underline-style == solid {
-        @include underline(
-          $color: $link-color-active,
-          $weight: .05,
-          $offset: $underline-offset
-        );
-      }
-
-      @if $underline-style == dashed or $underline-style == dotted {
-        background-image: none;
-      }
-    }
+    // @TODO Figure out why these styles don't work
+    // @media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+    //   @include underline(rgba($link-color-active, .4), $underline-offset, .5);
+    // }
   }
 }

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -234,7 +234,7 @@
         @include underlined-link(
           $link-color: $color-text,
           $link-color-active: $color-blue,
-          $underline-offset: .1rem
+          $underline-offset: 1px
         );
       }
     }


### PR DESCRIPTION
Use `px` instead of `rem` for underlined link mixin. It seems that somewhere along the line, `rem` stopped working. Changing values to `px`; this might be better anyway as we want absolute control over the underline size.

The mixin was simplified as well since we don't need different underline styles.

Fixes lonelyplanet/destinations-next#762