### PR TITLE
Fix issues with POI callout and refactor

### DIFF
--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -461,3 +461,40 @@ $alert-colors: (
     background-color: rgba(#000, .9);
   }
 }
+
+/// Clamps multi-line text
+/// @param {Value}          $font-size           - Font size of the text
+/// @param {Unitless Value} $line-height         - Line height of the text; **must be a unitless value**
+/// @param {Number}         $lines-to-show       - Number of lines to show
+/// @example scss
+/// p {
+///   @include line-clamp($font-size: 16px, $line-height: 1.5, $lines-to-show: 3);
+/// }
+@mixin line-clamp(
+  $font-size,
+  $line-height,
+  $lines-to-show
+) {
+  @if unitless($line-height) == false {
+    $line-height: create-unitless-line-height($font-size, $line-height);
+  }
+
+  -webkit-box-orient: vertical;
+  display: block; // Fallback for non-webkit browsers
+  display: -webkit-box;
+  height: ($font-size * $line-height * $lines-to-show); // Fallback for non-webkit browsers
+  -webkit-line-clamp: $lines-to-show;
+  overflow: hidden;
+  position: relative;
+  text-overflow: ellipsis;
+
+  // Fallback for non-webkit browsers
+  &::after {
+    background-color: #fff;
+    bottom: 0;
+    content: "\2026";
+    position: absolute;
+    text-align: left;
+    width: 100%;
+  }
+}

--- a/src/components/poi_callout/poi_callout.hbs
+++ b/src/components/poi_callout/poi_callout.hbs
@@ -1,6 +1,5 @@
-<div class="poi-callout__content">
-  <img src="{{ image }}" alt="">
-  <h3>{{ name }}</h3>
-  <h5>{{ topic }}</h5>
-  <p>{{ excerpt }}</p>
-</div>
+<a class="lp-poi-callout is-invisible"
+  href="#"
+  tabindex="-1"
+  role="dialog"
+  aria-hidden="true"></a>

--- a/src/components/poi_callout/poi_callout.js
+++ b/src/components/poi_callout/poi_callout.js
@@ -1,7 +1,6 @@
 import { Component } from "../../core/bane";
 import $ from "jquery";
 import debounce from "lodash/function/debounce";
-import $clamp from "clamp-js/clamp.js";
 
 export default class PoiCalloutComponent extends Component {
   initialize(options, {
@@ -41,7 +40,7 @@ export default class PoiCalloutComponent extends Component {
         : this.$el.offset().left - this.calloutWidth;
 
       this._windowEvents();
-    }, 10));
+    }, 100));
 
     this.$window.on("scroll.poi", debounce(() => {
       this._windowEvents();
@@ -50,7 +49,7 @@ export default class PoiCalloutComponent extends Component {
         updateArticleOffsetHeight = true;
         this.articleOffsetHeight = this.$el.height() + this.$el.offset().top;
       }
-    }, 10));
+    }, 100));
 
     this.$callout.on("mouseenter.poi", () => {
       clearTimeout(this.mouseoutTimeout);
@@ -158,8 +157,6 @@ export default class PoiCalloutComponent extends Component {
         excerpt: poiData.excerpt,
         image: poiData.image
       }));
-
-    $clamp(this.$callout.find(".lp-js-poi-callout-excerpt").get(0), { clamp: 3 });
   }
 
   /**

--- a/src/components/poi_callout/poi_callout.scss
+++ b/src/components/poi_callout/poi_callout.scss
@@ -34,13 +34,14 @@
 }
 
 .lp-poi-callout__excerpt {
-  font-size: 1.4rem;
+  $_font-size: 1.4rem;
+  $_line-height: (22 / 14);
+  @include line-clamp($_font-size, $_line-height, 3);
+  font-size: $_font-size;
   font-weight: 300;
-  height: 7rem;
-  line-height: (22 / 14);
+  line-height: $_line-height;
   margin-bottom: 0;
   margin-top: 1.6rem;
-  overflow: hidden;
 }
 
 .lp-poi-callout__image {

--- a/src/components/poi_callout/poi_callout.scss
+++ b/src/components/poi_callout/poi_callout.scss
@@ -1,17 +1,14 @@
 @import "../../../sass/webpack_deps";
 
-.poi-callout {
+.lp-poi-callout {
   background-color: #fff;
   box-shadow: .15rem .26rem 2.9rem rgba(#000, .08);
   color: $color-darkblue;
   display: block;
   max-height: 30rem;
   max-width: 25rem;
-  opacity: 0;
   padding: 2rem;
-  position: absolute;
   transition: 1000ms ease;
-  visibility: hidden;
   width: 25rem;
   z-index: z("middle");
 
@@ -19,12 +16,13 @@
     display: none;
   }
 
-  &:hover,
-  &:active,
-  &:focus {
-    .poi-callout__content h3 {
-      color: $color-blue;
-    }
+  body > & {
+    position: absolute;
+  }
+
+  &.is-invisible {
+    opacity: 0;
+    visibility: hidden;
   }
 
   &.is-visible {
@@ -35,7 +33,7 @@
   }
 }
 
-.poi-callout__content p {
+.lp-poi-callout__excerpt {
   font-size: 1.4rem;
   font-weight: 300;
   height: 7rem;
@@ -45,19 +43,25 @@
   overflow: hidden;
 }
 
-.poi-callout__content img {
+.lp-poi-callout__image {
   margin-bottom: 1.8rem;
 }
 
-.poi-callout__content h3 {
+.lp-poi-callout__title {
   color: #29313e;
   font-size: 1.6rem;
   font-weight: 600;
   line-height: (20 / 16);
   transition: color 200ms ease;
+
+  .lp-poi-callout:hover &,
+  .lp-poi-callout:active &,
+  .lp-poi-callout:focus & {
+    color: $color-blue;
+  }
 }
 
-.poi-callout__content h5 {
+.lp-poi-callout__type {
   color: #6d6d6d;
   font-family: $miller-daily;
   font-size: 1.6rem;

--- a/src/components/poi_callout/poi_callout_content.hbs
+++ b/src/components/poi_callout/poi_callout_content.hbs
@@ -1,0 +1,6 @@
+<div class="lp-poi-callout__content">
+  <img class="lp-poi-callout__image lp-js-poi-callout-image" src="{{ image }}" alt="">
+  <h3 class="lp-poi-callout__title">{{ name }}</h3>
+  <h5 class="lp-poi-callout__type">{{ topic }}</h5>
+  <div class="lp-poi-callout__excerpt lp-js-poi-callout-excerpt">{{ excerpt }}</div>
+</div>


### PR DESCRIPTION
On articles with large images, the height of the article was calculated incorrectly and so POI callouts at the end of the article were appearing too high on the page and out of view. This problem was solved by recalculating the article height one time on the scroll event.

Added line clamping back.

Also some refactoring:

- Namespace component
- Create template for callout content, move template for callout out of JS

Fixes lonelyplanet/destinations-next#761 and fixes lonelyplanet/destinations-next#756