### PR TITLE
Improve article when JS is disabled

### DIFF
--- a/src/components/article/article.scss
+++ b/src/components/article/article.scss
@@ -18,6 +18,10 @@
   overflow: hidden; // Prevent horizontal movement in iOS caused by .size-full images
   position: relative;
 
+  .no-js & {
+    border-bottom: 0;
+  }
+
   &.is-loading {
     opacity: 0;
   }
@@ -46,6 +50,10 @@
   .no-flexbox & {
     display: block;
   }
+
+  .no-js & {
+    display: none;
+  }
 }
 
 .article__sponsor-ad {
@@ -66,5 +74,9 @@
 
   .article & {
     margin-top: 4rem;
+  }
+
+  .no-js & {
+    display: none;
   }
 }

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -38,7 +38,14 @@ export default class ArticleComponent extends Component {
     this.listOfArticles = [];
     this.state = {};
 
+    this.$globalFooter = $(".lp-global-footer");
+
     this._setFirstArticle();
+    this._detachGlobalFooter();
+  }
+
+  _detachGlobalFooter() {
+    this.$globalFooter.detach();
   }
 
   @subscribe("ad.loaded", "ads");
@@ -239,9 +246,10 @@ export default class ArticleComponent extends Component {
    */
   _getAmountNeededToScroll() {
     let roomToScroll = this._getRoomToScroll(),
-        amountToScrollPastEndOfArticle = 0;
+        amountToScrollPastEndOfArticle = 0,
+        globalFooterHeight = this.$globalFooter.height();
 
-    return roomToScroll - amountToScrollPastEndOfArticle;
+    return roomToScroll - amountToScrollPastEndOfArticle - globalFooterHeight;
   }
 
   /**

--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -356,5 +356,9 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     @media (min-width: $min-960) {
       text-align: right;
     }
+
+    .no-js & {
+      display: none;
+    }
   }
 }


### PR DESCRIPTION
There are a few things here that will improve the article experience when JS is disabled.

1. Hide wrappers for ads
2. Hide article footer; this area contains the publish date (JS formatted) and the social share component (requires JS)
3. Add the global footer back in; when JS is disabled and the footer is missing, the page looks broken; the footer can be detached in a JS enabled environment