### PR TITLE
Remove resrc.it urls from interests component

### DIFF
--- a/src/components/interests/interests.hbs
+++ b/src/components/interests/interests.hbs
@@ -5,8 +5,8 @@
     <section class="interests__cards interests__cards--{{ interests.count }}">
       {{#each interests.cards}}
         <a class="interests__card interests__card--{{ order }}" href="{{ url }}">
-          <div class="interests__card--inner" style="background-image: url( https://images-resrc.staticlp.com/S=H350/C=AR350x350,XOF50/O=90/E=S/{{ src }} )">
-            
+          <div class="interests__card--inner" style="background-image: url( {{ src }} )">
+
             <div class="interests__card__bottom">
               <span class="interests__card__link">
                 {{ interest }}


### PR DESCRIPTION
We no longer use resrc.it and this is handled in the backend via ImageFormatter.