### PR TITLE
Get next article sooner

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -206,7 +206,7 @@ export default class ArticleComponent extends Component {
         this.stickyFooterComponent.recalculate(this._getAmountNeededToScroll());
         this.viewedArticles[this.howManyArticlesHaveLoaded - 1].scroll.amountNeededToScroll = this._getAmountNeededToScroll();
       }
-    }, 100));
+    }, 50));
   }
 
   _setActiveArticle() {
@@ -218,7 +218,7 @@ export default class ArticleComponent extends Component {
   _shouldGetNextArticle(difference) {
     let amountNeededToScroll = this._getAmountNeededToScroll();
 
-    return this.$window.scrollTop() >= (amountNeededToScroll - difference);
+    return this.$window.scrollTop() >= ((amountNeededToScroll - difference) * 0.8);
   }
 
   /**


### PR DESCRIPTION
Once an article is 80% viewed, the next one will be fetched. Hopefully, this will help with ad impressions and viewability.

Also decreased the debounce to trigger the scroll event more often.

Fixes #392