### PR TITLE
Removing perf marks

### DIFF
--- a/src/core/perf_monitor.js
+++ b/src/core/perf_monitor.js
@@ -14,7 +14,8 @@ export default class PerfMonitor {
     return `mark_${RizzoEvents.LOAD_BELOW}`;
   }
   constructor() {
-    this.subscribe();
+    // Disabling for now to see if webpagetest works without them
+    // this.subscribe();
   }
   /**
    * Listens for when our critical code is loaded and creates a perf mark


### PR DESCRIPTION
For some reason these seem to be breaking webpagetest.org which is an important tool for us, disabling to see if it helps.

https://github.com/WPO-Foundation/webpagetest/issues/543#issuecomment-187387367