### PR TITLE
Add a reset for accurate next article calculation

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -22,7 +22,7 @@ export default class ArticleComponent extends Component {
 
     this._resetWindowScrollPosition();
 
-    this.$document = $(document);
+    this.$document = $("html");
     this.$window = $(window);
 
     this.isNextArticleLoading = false;
@@ -221,9 +221,11 @@ export default class ArticleComponent extends Component {
   }
 
   _shouldGetNextArticle(difference) {
+    let reset = this.$newArticle ? this.$newArticle.offset().top : 0;
     let amountNeededToScroll = this._getAmountNeededToScroll();
+    let calculatedAmount = (amountNeededToScroll - difference - reset) * 0.8;
 
-    return this.$window.scrollTop() >= ((amountNeededToScroll - difference) * 0.8);
+    return this.$window.scrollTop() - reset >= calculatedAmount;
   }
 
   /**


### PR DESCRIPTION
With the 80% threshold, the amount needed to scroll decreased with each new article load. This
caused new articles to load prior to the 80% threshold. The solution was to reset the `scrollTop`
_and_ the `calculatedAmount` values with the top offset of the new article (which is the sum of
height of all articles before the new one).

Also, I noticed that `$(document).height()` and `$("html").height()` produced different results; I
couldn't figure out why. The value for `$("html").height()` is accurate while the value for
`$(document).height()` is too much. This change improves the accuracy of the progress bar and the
loading of a new article.

Fixes lonelyplanet/destinations-next#793