### PR TITLE
Update masthead text

### DIFF
--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -49,10 +49,14 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
   &__text-wrap {
     align-items: center;
     bottom: 0;
-    box-sizing: content-box;
     display: flex;
     justify-content: center;
+    left: 0;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 90%;
     position: absolute;
+    right: 0;
     top: 0;
     width: 100%;
     z-index: z("middle");
@@ -77,6 +81,7 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
 
   &__text {
     @include container-padded();
+    max-width: 100%; // override container mixin’s default; causes off-centered text in IE
     text-align: center;
     width: 100%;
 


### PR DESCRIPTION
- Set a max width and center it (matches max-width on slideshow)
- Override the max width provided by the container mixin; fixes an IE bug