### PR TITLE
Introduce normalize.css; separate from reset.css

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -8,6 +8,7 @@ exclude:
 - 'docs/**'
 - 'node_modules/**'
 - 'tmp/**'
+- 'sass/generic/_normalize.scss' # 3rd-party code
 - 'src/components/image_gallery/image_gallery.scss' # plugin code
 - 'src/components/map/**' # temporary exclusion; needs refactored
 plugin_directories: ['.scss-linters']

--- a/sass/core.scss
+++ b/sass/core.scss
@@ -1,5 +1,6 @@
 @import "generic/fonts";
 @import "webpack_deps"; // settings and tools
+@import "generic/normalize";
 @import "generic/reset";
 @import "base/base";
 @import "objects/objects";

--- a/sass/generic/_normalize.scss
+++ b/sass/generic/_normalize.scss
@@ -1,0 +1,424 @@
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS and IE text size adjust after device orientation change,
+ *    without disabling user zoom.
+ */
+
+html {
+  font-family: sans-serif; /* 1 */
+  -ms-text-size-adjust: 100%; /* 2 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+}
+
+/**
+ * Remove default margin.
+ */
+
+body {
+  margin: 0;
+}
+
+/* HTML5 display definitions
+   ========================================================================== */
+
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+
+audio,
+canvas,
+progress,
+video {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
+ * Prevent displaying `audio` without controls in Mobile Safari 4/5/6/7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
+ */
+
+[hidden],
+template {
+  display: none;
+}
+
+/* Links
+   ========================================================================== */
+
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+}
+
+/**
+ * Improve readability of focused elements when they are also in an
+ * active/hover state.
+ */
+
+a:active,
+a:hover {
+  outline: 0;
+}
+
+/* Text-level semantics
+   ========================================================================== */
+
+/**
+ * Address inconsistent styling of `abbr[title]`.
+ * 1. Correct styling in Firefox 39 and Opera 12.
+ * 2. Correct missing styling in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: underline; /* 2 */
+  text-decoration: underline dotted; /* 2 */
+}
+
+/**
+ * Address inconsistent styling of b and strong.
+ * 1. Correct duplicate application of `bolder` in Safari 6.0.2.
+ * 2. Correct style set to `bold` in Edge 12+, Safari 6.2+, and Chrome 18+.
+ */
+
+b,
+strong {
+  font-weight: inherit; /* 1 */
+}
+
+b,
+strong {
+  font-weight: bolder; /* 2 */
+}
+
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+
+dfn {
+  font-style: italic;
+}
+
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/**
+ * Address styling not present in IE 8/9.
+ */
+
+mark {
+  background-color: #ff0;
+  color: #000;
+}
+
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sup {
+  top: -0.5em;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+/* Embedded content
+   ========================================================================== */
+
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+
+img {
+  border: 0;
+}
+
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * Address inconsistent styling of `hr`.
+ * 1. Correct `box-sizing` set to `border-box` in Firefox.
+ * 2. Correct `overflow` set to `hidden` in IE 8/9/10/11 and Edge 12.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * Contain overflow in all browsers.
+ */
+
+pre {
+  overflow: auto;
+}
+
+/**
+ * 1. Correct inheritance and scaling of font-size for preformatted text.
+ * 2. Address odd `em`-unit font size rendering in all browsers.
+ */
+
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Forms
+   ========================================================================== */
+
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+
+/**
+ * 1. Correct font properties not being inherited.
+ * 2. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font: inherit; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+
+button {
+  overflow: visible;
+}
+
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+
+button,
+select {
+  text-transform: none;
+}
+
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+
+button,
+html input[type="button"], /* 1 */
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+ * Re-set default cursor for disabled elements.
+ */
+
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/**
+ * Restore focus style in Firefox 4+ (unset by a rule above)
+ */
+
+button:-moz-focusring,
+input:-moz-focusring {
+  outline: 1px dotted ButtonText;
+}
+
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+
+input {
+  line-height: normal;
+}
+
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+ * Address `appearance` set to `searchfield` in Safari and Chrome.
+ */
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+}
+
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+ * Define consistent border, margin, and padding.
+ */
+
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+
+legend {
+  border: 0; /* 1 */
+  padding: 0; /* 2 */
+}
+
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Restore font weight (unset by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+
+optgroup {
+  font-weight: bold;
+}

--- a/sass/generic/_reset.scss
+++ b/sass/generic/_reset.scss
@@ -1,139 +1,24 @@
 // -----------------------------------------------------------------------------
-// Html5 Elements
-// -----------------------------------------------------------------------------
-
-article, aside, details, figcaption, figure,
-footer, header, hgroup, nav, section, summary,
-iframe {
-  display: block;
-}
-
-time {
-  display: inline;
-}
-
-// -----------------------------------------------------------------------------
-// Slim Normalize - See normalize source code for clarification on rule purposes
-//
-// I have slimmed it down to adapt it for our supported browser set
-//
-// https://github.com/necolas/normalize.css
+// Slim Reset
 // -----------------------------------------------------------------------------
 
 html {
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
-  overflow-y: scroll;
   -webkit-tap-highlight-color: transparent;
   text-rendering: optimizeLegibility;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
 }
 
 *,
 *::before,
 *::after {
-  box-sizing: border-box;
+  box-sizing: inherit;
 }
 
 // Fixes jank with scrolling on iOS devices
 body {
   -webkit-overflow-scrolling: touch;
 }
-
-form,
-input,
-button,
-select,
-textarea {
-  font-size: 100%;
-}
-
-b,
-strong {
-  font-weight: bold;
-}
-
-//a:active, a:focus
-//  outline: 0
-//  background-color: rgba(255,255,255,0.0)
-
-img {
-  border: 0;
-  -ms-interpolation-mode: bicubic;
-  // Prevent some IE bugs in legacy code
-  max-width: 100%;
-}
-
-button,
-input,
-select,
-textarea {
-  border-radius: 0;
-  font-family: inherit;
-  font-size: 100%;
-  vertical-align: baseline;
-}
-
-button,
-input {
-  line-height: normal;
-  margin: 0;
-  overflow: visible;
-}
-
-[type="checkbox"],
-[type="radio"] {
-  box-sizing: border-box;
-}
-
-textarea {
-  overflow: auto;
-  vertical-align: top;
-}
-
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
-
-sub,
-sup {
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
-}
-
-sup {
-  top: -.45em;
-}
-
-sub {
-  bottom: -.25em;
-}
-
-button::-moz-focus-inner,
-input::-moz-focus-inner {
-  border: 0;
-  padding: 0;
-}
-
-// Override Chrome's agressive defaults
-hr {
-  border: 0;
-  border-bottom: 1px solid #dbe6ec;
-}
-
-// Address `[hidden]` styling not present in IE 8/9/10.
-// Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
-[hidden],
-template {
-  display: none;
-}
-
-// -----------------------------------------------------------------------------
-// Slim Reset
-// -----------------------------------------------------------------------------
 
 html, body, div, span, iframe, h1, h2, h3, h4, h5,
 h6, p, blockquote, pre, a, abbr, acronym, address,
@@ -155,6 +40,11 @@ a > img {
   display: block;
 }
 
+img {
+  -ms-interpolation-mode: bicubic; // Prevent some IE bugs in legacy code
+  max-width: 100%;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-weight: normal;
 }
@@ -163,31 +53,31 @@ fieldset {
   border: 0;
 }
 
-// ----------------------------------------------------------------------------
-//
-// Remove iOs default styles
-//
-// ----------------------------------------------------------------------------
-
-[type=text],
-[type=email],
-[type=search],
-[type=submit] {
-  @extend %webkit-appearance-reset;
+time {
+  display: inline;
 }
 
-[type=search]::-webkit-search-cancel-button {
-  @extend %webkit-appearance-reset;
+// Override Chrome's agressive defaults
+hr {
+  border: 0;
+  border-bottom: 1px solid #dbe6ec;
 }
 
-[type=search]::-webkit-search-decoration {
-  @extend %webkit-appearance-reset;
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
-[type=search]::-webkit-search-results-button {
-  @extend %webkit-appearance-reset;
+button,
+input,
+select,
+textarea {
+  border-radius: 0;
+  font-family: inherit;
+  vertical-align: baseline;
 }
 
-[type=search]::-webkit-search-results-decoration {
-  @extend %webkit-appearance-reset;
+button,
+select {
+  line-height: normal;
 }


### PR DESCRIPTION
This PR adds the full normalize.css and separates normalize styles from reset
styles. Previously, there were some normalize styles mixed in with reset styles,
but it'd be better to include the full normalize.css rather than parts of it
(for better cross-browser consistency) and separate it from reset (since they
are technically two different things).

Also this PR changes box-sizing on the universal selector to inherit as this is
a slightly better practice. See http://cl.ly/1w3T0E302y03