### PR TITLE
Update non-flexbox layout for masthead

### DIFF
--- a/src/components/masthead/_masthead.scss
+++ b/src/components/masthead/_masthead.scss
@@ -60,6 +60,13 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     top: 0;
     width: 100%;
     z-index: z("middle");
+
+    .no-flexbox & {
+      display: table;
+      height: 100%;
+      max-width: 100%;
+      width: 100%;
+    }
   }
 
   &__text-wrap--pull-up {
@@ -88,18 +95,12 @@ $masthead-straplines-height-large: (4.1rem + 2.4rem); // height + margin-bottom
     @media (min-width: $min-720) {
       margin-top: $header-height-mobile;
     }
-  }
 
-  .no-flexbox &__text {
-    display: table;
-    height: 100%;
-    width: 100%;
-  }
-
-  .no-flexbox &__container {
-    display: table-cell;
-    text-align: center;
-    vertical-align: middle;
+    .no-flexbox & {
+      display: table-cell;
+      text-align: center;
+      vertical-align: middle;
+    }
   }
 
   &__breadcrumb {

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -1,7 +1,3 @@
-<!--
-By use of this code snippet, I agree to the Brightcove Publisher T and C
-found at https://accounts.brightcove.com/en/terms-and-conditions/.
--->
 <article class="masthead masthead--{{type}}{{#if masthead.first}} masthead--has-images{{else}} masthead--no-images{{/if}}" data-has-ad="false">
   {{#if video}}
   <div class="masthead__video-container js-video-container">


### PR DESCRIPTION
Centers text in IE 9 and other browsers that don't support flexbox. The no-flexbox styles needed to be moved to different elements.

Fixes lonelyplanet/destinations-next#812