### PR TITLE
Fix cut off header in the footer

### DIFF
--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -225,7 +225,7 @@ $logo-height: 4rem;
   color: $darkgray;
   font-size: 1.2rem;
   font-weight: $font-weight-semibold;
-  line-height: 1;
+  line-height: inherit;
   text-transform: uppercase;
 
   @media (max-width: $max-960) {


### PR DESCRIPTION
The newsletter signup header was cut off. By inheriting the line height of the parent element, this no longer happens.

Resolves https://github.com/lonelyplanet/destinations-next/issues/825