### PR TITLE
Allow html encoded values in guidebook subtitle

### DIFF
--- a/src/components/guidebook/guidebook.hbs
+++ b/src/components/guidebook/guidebook.hbs
@@ -3,7 +3,7 @@
     <header class="guidebook__header">
       <h2 class="guidebook__title">{{ title }}</h2>
       {{#if subtitle }}
-        <p class="guidebook__subtitle">{{ subtitle }}</p>
+        <p class="guidebook__subtitle">{{{ subtitle }}}</p>
       {{/if}}
     </header>
 


### PR DESCRIPTION
This is because the subtitle is going to include currency values from Scooter, which uses html encoded values.