### PR TITLE
Change hotels form to use https

### DIFF
--- a/src/components/hotels/hotels.hbs
+++ b/src/components/hotels/hotels.hbs
@@ -13,7 +13,7 @@
         </p>
       </header>
 
-      <form class="hotels__search" id="hotel-search-form" action="http://www.lonelyplanet.com/{{slug}}/hotels">
+      <form class="hotels__search" id="hotel-search-form" action="https://www.lonelyplanet.com/{{slug}}/hotels">
         <fieldset>
           <div class="hotels__search__field">
             <label class="hotels__search__label" for="js-av-start">Check-in</label>


### PR DESCRIPTION
This component is being rendered on an https page, resulting in a user facing warning in some browsers that the form is insecure.