### PR TITLE
Adding ad template for sponsored articles

### DIFF
--- a/src/components/articles/articles.hbs
+++ b/src/components/articles/articles.hbs
@@ -44,4 +44,11 @@
       </a>
     </div>
   {{/if}}
+  <div class="article__sponsor-ad js-article-sponsor-ad">
+    <div class="adunit adunit--sponsor-logo display-none js-sponsor-logo"
+      id="sponsor-logo-article"
+      data-size-mapping="sponsor-logo"
+      data-targeting='{ "position": "article-list-last" }'>
+    </div>
+  </div>
 </article>

--- a/src/components/articles/articles.hbs
+++ b/src/components/articles/articles.hbs
@@ -45,7 +45,7 @@
     </div>
   {{/if}}
   <div class="article__sponsor-ad js-article-sponsor-ad">
-    <div class="adunit adunit--sponsor-logo display-none js-sponsor-logo"
+    <div class="adunit adunit--sponsor-logo display-none"
       id="sponsor-logo-article"
       data-size-mapping="sponsor-logo"
       data-targeting='{ "position": "article-list-last" }'>


### PR DESCRIPTION
In the list view, there was no template to hook into for sponsored articles. This adds that template to the articles handlebars file.