### PR TITLE
Linking Newsletter heading to newsletter page

### DIFF
--- a/src/components/footer/footer.hbs
+++ b/src/components/footer/footer.hbs
@@ -4,7 +4,9 @@
     <div class="lp-global-footer__main">
       <div class="lp-global-footer__main__links lp-global-footer__main__links--newsletter">
         <p class="lp-global-footer__main__links__header">
-          Newsletter sign up
+          <a href="http://www.lonelyplanet.com/newsletter" data-lpa-category="Destinations Next" data-lpa-action="Footer Click" data-lpa-label="Newsletter">
+            Newsletter sign up
+          </a>
         </p>
 
         <form class="newsletter-register" action="//www.lonelyplanet.com/newsletter/form-submission.php" method="post" _lpchecked="1">


### PR DESCRIPTION
Previously there was no link to the newsletter page from "Newsletter Sign In". This fixes that.