### PR TITLE
Evidently trackJs automatically uses window.onerror

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": "node bin/rizzo build"
   },
-  "version": "0.11.46",
+  "version": "0.11.47",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/src/common.js
+++ b/src/common.js
@@ -29,12 +29,6 @@ FastClick.attach(document.body);
 
 if (typeof ENV_PROD !== "undefined" && ENV_PROD) {
   require("trackjs");
-
-  window.onerror = function(message, file, line, col) {
-    rizzo.logger.error({
-      message, file, line, col
-    });
-  };
 }
 
 let cookie = new CookieUtil();

--- a/src/core/ads/ad_manager.js
+++ b/src/core/ads/ad_manager.js
@@ -83,7 +83,7 @@ export default class AdManager {
       $adunit.data("adUnit", currentUnit);
     }
 
-    if (!currentUnit.isEmpty()) {
+    if (currentUnit && !currentUnit.isEmpty()) {
       this._track($adunit);
     }
 

--- a/src/core/ads/ad_sizes.js
+++ b/src/core/ads/ad_sizes.js
@@ -11,7 +11,7 @@ export default {
   ],
   "leaderboard-responsive": [
     { browser: [ 970, 0 ], ad_sizes: [ [ 1000, 500 ], [ 970, 250 ], [ 970, 90 ], [ 970, 66 ], [ 728, 90 ], [ 1, 1 ] ] },
-    { browser: [  ], ad_sizes: [[ 728, 90 ], [1, 1]] },
+    { browser: [ 728, 0 ], ad_sizes: [[ 728, 90 ], [1, 1]] },
     { browser: [ 0, 0 ], ad_sizes: [[ 300, 250 ], [ 320, 50 ], [1, 1]] }
   ],
   "leaderboard-content": [


### PR DESCRIPTION
No need for window.onerror anymore with trackjs.