### PR TITLE
Add missing category and label to gotoPlace event

### DIFF
--- a/src/components/map/actions.js
+++ b/src/components/map/actions.js
@@ -47,7 +47,8 @@ class MapActions {
     });
 
     return {
-      place
+      category: "Destinations Next",
+      label:    placeTitle
     };
   }
 


### PR DESCRIPTION
Fixes "Map goToPlace" event not firing.