### PR TITLE
Fix issue with overlay for shop

### DIFF
--- a/lib/templates/rizzo-next-build.hbs
+++ b/lib/templates/rizzo-next-build.hbs
@@ -2,6 +2,7 @@
 import "babel-polyfill";
 import "matchmedia-polyfill/matchMedia";
 import "matchmedia-polyfill/matchMedia.addListener";
+import "../src/components/svg_icons";
 
 {{#each components}}
 import {{name}} from "{{path}}";

--- a/src/components/overlay/index.js
+++ b/src/components/overlay/index.js
@@ -10,7 +10,7 @@ class Overlay extends Component {
     this.options = options;
 
     this.$html = $("html");
-    this.$el.addClass("overlay");
+    this.$el.addClass("lp-overlay");
 
     this.events = {
       "click": "onClick",
@@ -45,7 +45,7 @@ class Overlay extends Component {
     getScrollbarWidth()
       .then((scrollWidth) => {
         setTimeout(() => {
-          this.$el.addClass("overlay--visible");
+          this.$el.addClass("lp-overlay--visible");
         }, 10);
 
         if (this.options.preventScroll) {
@@ -65,7 +65,7 @@ class Overlay extends Component {
       return Promise.all([]);
     }
 
-    this.$el.removeClass("overlay--visible");
+    this.$el.removeClass("lp-overlay--visible");
 
     this.isVisible = false;
 

--- a/src/components/overlay/index.scss
+++ b/src/components/overlay/index.scss
@@ -1,6 +1,6 @@
 @import "../../../sass/webpack_deps";
 
-.overlay {
+.lp-overlay {
   background-color: rgba($color-black, .4);
   bottom: 0;
   left: 0;


### PR DESCRIPTION
The `.overlay` class was overriding some things in Rizzo and covering the page on shop.