### PR TITLE
Get hotels component title from the view

### DIFF
--- a/src/components/hotels/hotels.hbs
+++ b/src/components/hotels/hotels.hbs
@@ -4,7 +4,7 @@
 
       <header class="hotels__header">
         <h2 class="hotels__title">
-          Amazing hotels and hostels
+          {{{hotels_title}}}
         </h2>
 
         <p class="hotels__text">


### PR DESCRIPTION
This will allow for promotions like the Rio takeover to alter the title of the hotels component.