### PR TITLE
Fix slug in masthead nav

### DIFF
--- a/src/components/masthead/masthead_nav.hbs
+++ b/src/components/masthead/masthead_nav.hbs
@@ -1,11 +1,11 @@
 <div class="masthead_nav" data-lpa-category="Navigation Click" data-lpa-action="Masthead">
   <div class="masthead_nav__container">
-    <a class="masthead_nav__link" href="/{{prev.slug}}">
+    <a class="masthead_nav__link" href="{{prev.slug}}">
       <i class="icon-chevron-left" aria-hidden="true"></i>
       {{prev.title}}
     </a>
 
-    <a class="masthead_nav__link" href="/{{next.slug}}">
+    <a class="masthead_nav__link" href="{{next.slug}}">
       {{next.title}}
       <i class="icon-chevron-right" aria-hidden="true"></i>
     </a>


### PR DESCRIPTION
The slug contains a slash and for some reason, putting an extra slash in the `href` removes the slash instead of doubling it.