### PR TITLE
Fix issues with yieldmo tag

### DIFF
--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -136,16 +136,15 @@ export default class ArticleBodyComponent extends Component {
     });
   }
 
-  _appendAd($paragraphs, featuredImage) {
+  _appendAd($paragraphs, $featuredImage) {
     const element = `<div
-      id="ad-article"
       class="adunit adunit--article display-none"
       data-dfp-options='{ "namespace": "LonelyPlanet.com/Yieldmo" }'
       data-size-mapping="mpu-double"
       data-targeting='{ "position": "article-paragraph" }'></div>`;
 
-    if(featuredImage.length) {
-      featuredImage.after(element);
+    if($featuredImage.length) {
+      $featuredImage.eq(0).after(element);
     } else {
       $paragraphs.eq(1).after(element);
     }


### PR DESCRIPTION
We were getting a bunch of errors in TrackJS about an exception being thrown in DFP.

The issue was, we were adding the tag WAY to many times because it was adding it after every image in the article. And we were reusing ID's which is also a no no in DFP.