### PR TITLE
Fix navigation hover bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": "node bin/rizzo build"
   },
-  "version": "0.11.73",
+  "version": "0.11.74",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/sass/tools/_mixins.scss
+++ b/sass/tools/_mixins.scss
@@ -215,7 +215,11 @@
   position: absolute;
   top: $top;
   transform: translateY(1rem);
-  transition: opacity $animation-speed, transform $animation-speed, box-shadow ($animation-speed-ui * 1.5);
+  transition: opacity $animation-speed,
+    transform $animation-speed,
+    box-shadow ($animation-speed-ui * 1.5),
+    visibility $animation-speed;
+  visibility: hidden;
   width: $width;
   z-index: z("global-header") + 1;
 }
@@ -225,6 +229,7 @@
   opacity: 1;
   pointer-events: all;
   transform: translateY(0);
+  visibility: visible;
 }
 
 @mixin dropdown-menu-arrow($size: 1.6rem, $left: 50%) {

--- a/src/components/logo/logo.scss
+++ b/src/components/logo/logo.scss
@@ -37,8 +37,10 @@
       width: 14.2rem;
     }
 
+    .ie9 &,
     .no-csstransforms & {
-      top: 3rem;
+      height: 100%;
+      top: 0;
     }
   }
 


### PR DESCRIPTION
The navigation menu was only invisible not actually hidden, so in some
cases (IE9), hovering over the area that the menu occupies would trigger
it and make it visible. `display` could not be used since it doesn't
allow for the animation, so `visibility` was used.

Also, fixes the logo position in IE9.

Closes #553