### PR TITLE
add adunit for badge

### DIFF
--- a/src/components/ads/ads.scss
+++ b/src/components/ads/ads.scss
@@ -46,7 +46,8 @@
 }
 
 .adunit--sponsor-logo,
-.adunit--sponsor-logo-masthead {
+.adunit--sponsor-logo-masthead,
+.adunit--best-in-masthead {
   display: inline-block;
 }
 
@@ -99,6 +100,10 @@
 .masthead__ad .adunit--sponsor-logo-masthead {
   display: inline-block;
   margin-bottom: -.9rem; // reset inline-block margin
+}
+
+.masthead__ad .adunit--best-in-masthead {
+  float: left;
 }
 
 .adunit--experiences {

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -68,7 +68,7 @@
     <div class="adunit adunit--best-in-masthead"
       id="best-in-badge-masthead"
       data-size-mapping="sponsor-logo"
-      data-targeting='{ "position": "masthead-best-in" }'>
+      data-targeting='{ "position": "masthead-best-in" }' data-dfp-options='{ "namespace": "LonelyPlanet.com/Editorial" }'>
     </div>
   </div>
 

--- a/src/components/masthead/masthead.hbs
+++ b/src/components/masthead/masthead.hbs
@@ -65,6 +65,11 @@
       data-size-mapping="sponsor-logo"
       data-targeting='{ "position": "masthead" }'>
     </div>
+    <div class="adunit adunit--best-in-masthead"
+      id="best-in-badge-masthead"
+      data-size-mapping="sponsor-logo"
+      data-targeting='{ "position": "masthead-best-in" }'>
+    </div>
   </div>
 
   {{#if masthead.masthead__cta}}

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -60,16 +60,12 @@ export default class MastheadComponent extends Component {
 
   @subscribe("ad.loaded", "ads");
   mastheadAdLoaded(data) {
-    if (data.id === "sponsor-logo-masthead") {
+    if (data.id === "sponsor-logo-masthead" || data.id === "best-in-badge-masthead") {
       let $mastheadAd = this.$el.find("#" + data.id);
 
       if ($mastheadAd.hasClass("display-block")) {
-        this.$el.find(".masthead__text-wrap")
+        this.$el.find(".masthead__text-wrap").removeClass("masthead__text-wrap--pull-up")
           .addClass("masthead__text-wrap--pull-up");
-      } else {
-        $mastheadAd
-          .closest(".js-masthead-ad")
-          .remove();
       }
     }
   }


### PR DESCRIPTION
request:

Add a new ad unit to support a “Best in” Badge for selected destinations. This ad unit should be created to perform like the unit that holds sponsorship logos on Destinations that have been sponsored. See https://www.lonelyplanet.com/ireland, and the small ad spot in the lower right hand side of the super zone. This is what we are needing for the lower LEFT hand side of the super zones.

*Requirements:*

- Create an add unit for the lower left corner of the superzone that acts just like the existing ad space  in the lower right corner, that’s populated with the “sponsored by” logo. (see screenshot below)

- This ad space should be available for any destination page to use (countries, cities, etc)

- The badge should be able to be populated to the destination via DFP.


-----------------------------------

New add unit will be targeted the same way `adunit--sponsor-logo-masthead` is (`window.lp.ads` config, per destination). Additionally there will be `"position": "masthead-best-in"` custom key targeting.