### PR TITLE
do not call fitText when there is no masthead title

### DIFF
--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -43,10 +43,13 @@ export default class MastheadComponent extends Component {
 
     this.listenTo(this.slideshow, "image.changed", this.updateStrapline);
 
-    fitText(this.$el.find(".js-masthead-title"), {
-      fontSizes: [ 56, 60, 80, 120 ],
-      minFontSize: 56
-    });
+    let mastheadTitle = this.$el.find(".js-masthead-title");
+    if (mastheadTitle.length) {
+      fitText(this.$el.find(".js-masthead-title"), {
+        fontSizes: [ 56, 60, 80, 120 ],
+        minFontSize: 56
+      });
+    }
 
     this.subscribe();
   }

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -45,7 +45,7 @@ export default class MastheadComponent extends Component {
 
     let mastheadTitle = this.$el.find(".js-masthead-title");
     if (mastheadTitle.length) {
-      fitText(this.$el.find(".js-masthead-title"), {
+      fitText(mastheadTitle, {
         fontSizes: [ 56, 60, 80, 120 ],
         minFontSize: 56
       });


### PR DESCRIPTION
In the new marketing campaign there will be no masthead title. Without this adjustment calling `fitText` would throw error (`Cannot read property 'length' of null` in `getWordCount`).