### PR TITLE
Style bug fixes for video player

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": " rimraf dist && mkdir -p dist && node bin/rizzo build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
   },
-  "version": "0.11.86",
+  "version": "0.11.87",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/src/components/video_overlay/_video_overlay.scss
+++ b/src/components/video_overlay/_video_overlay.scss
@@ -54,18 +54,11 @@
         margin-left: ($gutter * 2);
         margin-right: ($gutter * 2);
       }
-
-      @media (min-width: $min-1290) {
-        margin-left: 0;
-        margin-right: 0;
-      }
     }
-
-
   }
 
   .video-js {
-    display: inline-block;
+    margin: 0 auto;
   }
 
   .vjs-play-progress {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -6,6 +6,13 @@ import VideoOverlay from "../video_overlay";
 */
 export default class VideoPosterButtonComponent extends Component {
     initialize () {
+
+        // Temporary: querystring parameter video=true needs to be
+        // used to get the poster button to appear.
+        if (window.location.href.indexOf("video=true") == -1) {
+            return;
+        }
+
         this.overlay = new VideoOverlay({el: ".video-overlay"});
 
         this.events = {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -34,16 +34,18 @@ export default class VideoPosterButtonComponent extends Component {
         catch (e) {
         }
 
-        this.$el.find(".video-poster-button__poster").attr("src", image);
-        this.$el.find(".video-poster-button__title").text(title);
-
         if (!image) {
             this.$el.removeClass("video-poster-button--visible");
         }
-        else {
+
+        let imageEl = this.$el.find(".video-poster-button__poster")[0];
+        imageEl.onload = () => {
             this.$el.addClass("video-poster-button--visible");
-        }
-        
+        };
+        imageEl.src = image;
+
+        this.$el.find(".video-poster-button__title").text(title);
+
         return this;
     }
 


### PR DESCRIPTION
- Fixed black screen when in video player fullscreen mode
- Fixed responsiveness of video player
- Added temporary 'video=true' query parameter to enable video poster button
- Added workaround for low-res brightcove video when high-res video is available