### PR TITLE
add header with normal settings to build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 logs
 *.log
 
+#DS_Store
+.DS_Store
+
 # Runtime data
 pids
 *.pid

--- a/bin/rizzo.js
+++ b/bin/rizzo.js
@@ -16,11 +16,11 @@ program
   .option("-c, --config [config]", "Pass in a JSON configuration file")
   .action(function(components, options){
     const build = require("../lib/commands/build");
-    
+
     let config;
     if (options.config) {
       try {
-        config = require(options.conf);
+        config = require(options.config);
       } catch(e) {
         console.log("No config file found at %s", options.config);
         return program.exit(0);
@@ -28,7 +28,7 @@ program
     } else {
       config = require("../lib/data/default.json");
     }
-    
+
     if (options.dest) {
       config.dest = options.dest;
     }
@@ -37,7 +37,7 @@ program
       console.log("Done!");
     });
   });
-  
+
 program
   .command("create [name]")
   .description("Create a new rizzo component")

--- a/lib/data/default.json
+++ b/lib/data/default.json
@@ -1,6 +1,7 @@
 {
   "dest": "/dist",
   "components": {
+    "svg_icons": true,
     "header": {
       "type": "narrow",
       "search": {

--- a/lib/data/header_normal.json
+++ b/lib/data/header_normal.json
@@ -1,0 +1,122 @@
+{
+  "dest": "/dist/header_normal",
+  "components": {
+    "svg_icons": true,
+    "header": {
+      "type": "normal",
+      "images": true,
+      "search": {
+        "title": "Lonely Planet"
+      },
+      "navigation": [
+        {
+          "title": "Search",
+          "slug": "//www.lonelyplanet.com/search",
+          "css_class": "navigation__search--mobile"
+        },
+        {
+          "title": "Destinations",
+          "slug": "#",
+          "submenu": {
+            "featured": {
+              "image": "https://lonelyplanetstatic.imgix.net/marketing/2017/BIT/BIT-nav-image.png?w=80&h=60&fit=min",
+              "title": "Best in Travel",
+              "subtitle": "Featured",
+              "link": "//www.lonelyplanet.com/best-in-travel"
+            },
+            "items": [
+              {
+                "title": "Africa",
+                "slug": "https://www.lonelyplanet.com/africa"
+              },
+              {
+                "title": "Antarctica",
+                "slug": "https://www.lonelyplanet.com/antarctica-1007062"
+              },
+              {
+                "title": "Asia",
+                "slug": "https://www.lonelyplanet.com/asia"
+              },
+              {
+                "title": "Australia & Pacific",
+                "slug": "https://www.lonelyplanet.com/pacific"
+              },
+              {
+                "title": "Caribbean",
+                "slug": "https://www.lonelyplanet.com/caribbean"
+              },
+              {
+                "title": "Central America",
+                "slug": "https://www.lonelyplanet.com/central-america"
+              },
+              {
+                "title": "Europe",
+                "slug": "https://www.lonelyplanet.com/europe"
+              },
+              {
+                "title": "Middle East",
+                "slug": "https://www.lonelyplanet.com/middle-east"
+              },
+              {
+                "title": "North America",
+                "slug": "https://www.lonelyplanet.com/north-america"
+              },
+              {
+                "title": "South America",
+                "slug": "https://www.lonelyplanet.com/south-america"
+              }
+            ],
+            "call_to_action": {
+              "slug": "//www.lonelyplanet.com/places",
+              "title": "See All Countries"
+            }
+          }
+        },
+        {
+          "title": "Bookings",
+          "slug": "#",
+          "submenu": {
+            "items": [
+              {
+                "title": "Insurance",
+                "slug": "https://www.lonelyplanet.com/travel-insurance"
+              },
+              {
+                "title": "Hotels",
+                "slug": "https://www.lonelyplanet.com/hotels"
+              },
+              {
+                "title": "Flights",
+                "slug": "https://www.lonelyplanet.com/flights"
+              },
+              {
+                "title": "Adventure tours",
+                "slug": "https://www.lonelyplanet.com/adventure-tours"
+              },
+              {
+                "title": "Sightseeing tours",
+                "slug": "https://www.lonelyplanet.com/sightseeing-tours"
+              },
+              {
+                "title": "Airport transfers",
+                "slug": "https://www.lonelyplanet.com/airport-transfers"
+              },
+              {
+                "title": "Car rental",
+                "slug": "https://www.lonelyplanet.com/car-rental"
+              }
+            ]
+          }
+        },
+        {
+          "title": "Shop",
+          "slug": "http://shop.lonelyplanet.com"
+        },
+        {
+          "title": "Sign In",
+          "slug": "//auth.lonelyplanet.com/users/sign_in"
+        }
+      ]
+    }
+  }
+}

--- a/lib/templates/rizzo-next-build.hbs
+++ b/lib/templates/rizzo-next-build.hbs
@@ -2,7 +2,6 @@
 import "babel-polyfill";
 import "matchmedia-polyfill/matchMedia";
 import "matchmedia-polyfill/matchMedia.addListener";
-import "../src/components/svg_icons";
 
 {{#each components}}
 import {{name}} from "{{path}}";

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
   "scripts": {
     "test": "karma start --single-run",
     "ci": "karma start",
+    "build": "rimraf dist && mkdir -p dist/header_normal && node bin/rizzo build && node bin/rizzo build -c ../lib/data/header_normal.json",
     "docs": "node-sass sass/docs.scss -o dist/css --include-path=node_modules && esdoc -c esdoc.json",
     "sassdoc": "./node_modules/.bin/sassdoc sass --theme neat",
     "lint": "./node_modules/.bin/eslint src --ext .js,.jsx",
     "scsslint": "scss-lint . --config .scss-lint.yml",
-    "prepublish": " rimraf dist && mkdir -p dist && node bin/rizzo build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
+    "prepublish": "npm run build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
   },
   "version": "0.11.89",
   "pre-commit": [


### PR DESCRIPTION
When importing rizzo-next components into projects using react we need a way to pull in the two different style headers that have already been built. 

This PR adds a separate config file that builds the header with the settings needed to accomplish this. 

