### PR TITLE
Video poster button video opens "inline" instead of in an overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": " rimraf dist && mkdir -p dist && node bin/rizzo build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
   },
-  "version": "0.11.88",
+  "version": "0.11.89",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -17,4 +17,8 @@
   &:active {
     background-color: $lpblue;
   }
+
+  @media (max-width: $max-480) {
+    transform: scale(.7);
+  }
 }

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -1,0 +1,20 @@
+@import "../../../sass/webpack_deps";
+
+.video-js {
+  margin: 0 auto;
+}
+
+.vjs-play-progress {
+  background-color: $lpblue;
+}
+
+.vjs-volume-level {
+  background-color: $lpblue;
+}
+
+.vjs-big-play-button {
+  &:hover,
+  &:active {
+    background-color: $lpblue;
+  }
+}

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -13,17 +13,10 @@ class Brightcove extends VideoPlayer {
 
   initialize(options) {
     super.initialize(options);
-    this.events["click .video-js"] = "onClickVideo";
-  }
 
-  search() {
-    try {
-      let videoId = "ref:dest_" + window.lp.place.atlasId;
-      return Promise.resolve([videoId]);
-    }
-    catch (e) {
-      return Promise.resolve([]);
-    }
+    this.defaultAspectRatio = 1.77777778;
+
+    this.events["click .video-js"] = "onClickVideo";
   }
 
   onClickVideo(event) {
@@ -46,7 +39,28 @@ class Brightcove extends VideoPlayer {
     let self = this;
     videojs(this.videoEl).ready(function () {
       self.player = this;
+      self.setInitialDimensions();
       self.trigger("ready");
+    });
+  }
+
+  search() {
+    try {
+      let videoId = "ref:dest_" + window.lp.place.atlasId;
+      return Promise.resolve([videoId]);
+    }
+    catch (e) {
+      return Promise.resolve([]);
+    }
+  }
+
+  searchAndLoadVideo() {
+    return this.search().then((videos) => {
+      if (videos.length) {
+        let videoId = videos[0];
+        return this.loadVideo(videoId);
+      }
+      return new Promise.resolve(false);
     });
   }
 
@@ -64,6 +78,42 @@ class Brightcove extends VideoPlayer {
       });
     });
   }
+
+  /**
+  * Used to set the initial dimensions of the video player
+  * so that when video data begins to load, it sees that the player is fairly
+  * large and loads high-res video data.  We have an issue with Brightcove at the moment
+  * where it seems to load lower-res video if the player size is set to "mobile-like" 
+  * dimensions, but we want to make sure we always have high-res video loaded (if available).
+  */
+  setInitialDimensions() {
+    let width = 1280;
+    let height = width / this.defaultAspectRatio;
+
+    $(this.videoEl).css({ width: width, height: height});
+  }
+
+  getIdealDimensions(maxw, maxh) {
+    let ratio = this.defaultAspectRatio;
+    // If we have video data, use the aspect ratio of the 
+    // video as the width-height ratio value
+    try {
+      let source = this.player.mediainfo.rawSources[0];
+      ratio = source.width / source.height;
+    }
+    catch (e) {}
+
+    let width = maxw;
+    let height = maxw / ratio;
+
+    if ((typeof maxh != "undefined") && (height > maxh)) {
+      height = maxh;
+      width = height * ratio;
+    }
+
+    return { width: width, height: height };
+  }
+
 }
 
 export default Brightcove;

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -4,6 +4,11 @@ import VideoPlayer from "./video_player";
 
 class Brightcove extends VideoPlayer {
 
+  initialize(options) {
+    super.initialize(options);
+    this.events["click .video-js"] = "onClickVideo";
+  }
+
   get videoEl() {
     if (this.$el.hasClass("video-js")) {
       return this.el;
@@ -11,17 +16,8 @@ class Brightcove extends VideoPlayer {
     return this.$el.find(".video-js")[0];
   }
 
-  initialize(options) {
-    super.initialize(options);
-
-    this.defaultAspectRatio = 1.77777778;
-
-    this.events["click .video-js"] = "onClickVideo";
-  }
-
   onClickVideo(event) {
-    // Prevent event from bubbling -- added for VideoOverlayComponent
-    // to prevent the overlay from closing when the user uses the video embed.
+    // Prevent event from bubbling into the UI when the user interacts with the video
     event.stopPropagation();
   }
 
@@ -73,6 +69,7 @@ class Brightcove extends VideoPlayer {
       this.player.catalog.getVideo(videoId, (error, video) => {
         if (!error) {
           this.player.catalog.load(video);
+          this.renderSEOMarkup();
         }
         resolve(!error);
       });
@@ -80,12 +77,15 @@ class Brightcove extends VideoPlayer {
   }
 
   /**
-  * Used to set the initial dimensions of the video player
-  * so that when video data begins to load, it sees that the player is fairly
-  * large and loads high-res video data.  We have an issue with Brightcove at the moment
-  * where it seems to load lower-res video if the player size is set to "mobile-like" 
-  * dimensions, but we want to make sure we always have high-res video loaded (if available).
-  */
+   * Used to set the initial dimensions of the video player
+   * so that when video data begins to load, it sees that the player is fairly
+   * large and loads high-res video data.  We have an issue with Brightcove at the moment
+   * where it seems to load lower-res video if the player size is set to "mobile-like" 
+   * dimensions, but we want to make sure we always have high-res video loaded (if available).
+   *
+   * This is run when the player is initially setup so consider resizing
+   * this.videoEl before making the player visible.
+   */
   setInitialDimensions() {
     let width = 1280;
     let height = width / this.defaultAspectRatio;
@@ -93,8 +93,15 @@ class Brightcove extends VideoPlayer {
     $(this.videoEl).css({ width: width, height: height});
   }
 
+  /**
+   * Gets the ideal dimensions of the video, considering it's aspect ratio.
+   * @param {number} maxw - (required) Maximum width to return (pixels)
+   * @param {number} maxh - (optional) Maximum height to return (pixels) 
+   * @return {Object} object with 'width' and 'height' attributes
+   */
   getIdealDimensions(maxw, maxh) {
     let ratio = this.defaultAspectRatio;
+
     // If we have video data, use the aspect ratio of the 
     // video as the width-height ratio value
     try {
@@ -112,6 +119,129 @@ class Brightcove extends VideoPlayer {
     }
 
     return { width: width, height: height };
+  }
+
+  /**
+   * Retrieves metadata from the currently loaded video
+   * @param {string} name - The metadata attribute to retrieve a value for
+   * @returns The metadata value, or undefined if unable to retrieve the value
+   */
+  getVideoProperty (name) {
+    if (!this.player || !this.player.mediainfo) {
+      return;
+    }
+
+    return this.player.mediainfo[name];
+  }
+
+  /**
+   * Retrieves SEO-friendly metadata about the "source" of the currently loaded video
+   * @returns {Object} object with 'url', 'width', and 'height' 
+   *   attributes, null if unable to retrieve valid metadata
+   */
+  getVideoSourceData () {
+
+    if (!this.player || !this.player.mediainfo) {
+      return null;
+    }
+
+    // Schema.org VideoObject valid types include:
+    //   .mpg, .mpeg, .mp4, .m4v, .mov, .wmv, .asf, .avi, .ra, .ram, .rm, .flv
+    //   (Some of these are skipped here because they pertain to audio-only file types)
+    //   https://developers.google.com/webmasters/videosearch/schema
+    let validTypes = [
+      "video/mpeg",
+      "video/mp4",
+      "video/x-m4v",
+      "video/quicktime",
+      "video/x-ms-wmv",
+      "video/x-ms-asf",
+      "video/x-msvideo",
+      "application/vnd.rn-realmedia",
+      "video/x-flv"
+    ];
+
+    let url = null;
+    let width = 0;
+    let height = 0;
+
+    $.each(this.player.mediainfo.sources, function (i, source) {
+      if (!source.type || validTypes.indexOf(source.type.toLowerCase()) == -1) {
+        return;
+      }
+
+      if (!url || (width < source.width)) {
+        url = source.src;
+        width = source.width;
+        height = source.height;
+      }
+    });
+
+    return url ? { url: url, width: width, height: height } : null;
+  }
+
+  /**
+   * Uses the currently loaded video data to build a block of 
+   * LD-JSON Schema.org markup and appends it to the "head" tag
+   *
+   * This is run automatically when any video is loaded.
+   */
+  renderSEOMarkup () {
+    if (!this.player || !this.player.mediainfo) {
+      return;
+    }
+
+    let videoId = this.getVideoProperty("id");
+    let scriptId = "ldjson-video-" + videoId;
+    let script = document.getElementById(scriptId);
+    if (script) {
+      return;
+    }
+
+    let src = this.getVideoSourceData();
+    if (!src) {
+      return;
+    }
+
+    let defaultDescription = "";
+    try {
+      defaultDescription = window.lp.place.name;
+    }
+    catch (e) {
+    }
+
+    // Duration must be in ISO 8601 format
+    // https://en.wikipedia.org/wiki/ISO_8601#Durations
+    // Brightcove returns the number of seconds (ex. 161.685)
+    let seconds = Math.ceil(this.getVideoProperty("duration"));
+    let duration = "PT" + seconds + "S";
+
+    let embedUrl = "http://players.brightcove.net/5104226627001/default_default/index.html?videoId=" + videoId;
+
+    let data = {
+      "@context": "http://schema.org",
+      "@type": "VideoObject",
+      "name": this.getVideoProperty("name") || defaultDescription,
+      "description": this.getVideoProperty("description") || defaultDescription,
+      "thumbnailURL": this.getVideoProperty("thumbnail"),
+      "contentURL": src.url,
+      "embedURL": embedUrl,
+      "duration": duration,
+      "uploadDate": this.getVideoProperty("createdAt"),
+
+      // Leaving width and height off because they are optional and the width and height returned from
+      // this.getVideoSourceData() isn't necessarily the largest dimensions the video can be rendered at.
+      // All source data in brightcove's video metadata uses the same value for "contentURL" above, so 
+      // Google, Bing, etc. should be able to determine the resolution of the video on their own.
+      // "height": src.height,
+      // "width": src.width,
+    };
+
+    script = document.createElement("script");
+    script.id = scriptId;
+    script.type = "application/ld+json";
+    script.innerHTML = JSON.stringify(data);
+    document.getElementsByTagName("head")[0].appendChild(script);
   }
 
 }

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -17,7 +17,8 @@ class Brightcove extends VideoPlayer {
   }
 
   onClickVideo(event) {
-    // Prevent event from bubbling into the UI when the user interacts with the video
+    // Prevent event from bubbling into the UI 
+    // when the user interacts with the video.
     event.stopPropagation();
   }
 
@@ -35,6 +36,7 @@ class Brightcove extends VideoPlayer {
     let self = this;
     videojs(this.videoEl).ready(function () {
       self.player = this;
+      self.player.on("ended", () => { self.trigger("ended"); });
       self.setInitialDimensions();
       self.trigger("ready");
     });
@@ -87,10 +89,14 @@ class Brightcove extends VideoPlayer {
    * this.videoEl before making the player visible.
    */
   setInitialDimensions() {
+    if (!this.player) {
+      return;
+    }
+
     let width = 1280;
     let height = width / this.defaultAspectRatio;
 
-    $(this.videoEl).css({ width: width, height: height});
+    this.player.dimensions(width, height);
   }
 
   /**
@@ -135,7 +141,9 @@ class Brightcove extends VideoPlayer {
   }
 
   /**
-   * Retrieves SEO-friendly metadata about the "source" of the currently loaded video
+   * Retrieves SEO-friendly metadata about the highest-resolution "source" 
+   * of the currently loaded video
+   *
    * @returns {Object} object with 'url', 'width', and 'height' 
    *   attributes, null if unable to retrieve valid metadata
    */

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -1,5 +1,7 @@
 import Brightcove from "./brightcove";
 
+require("./_video.scss");
+
 let players = new Map();
 players.set("brightcove", Brightcove);
 

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -4,6 +4,7 @@ class VideoPlayer extends Component {
 
   initialize({ playerId }) {
     this.playerId = playerId;
+    this.defaultAspectRatio = 1.77777778;
     this.events = {};
     this.setup();
   }

--- a/src/components/video_overlay/_video_overlay.scss
+++ b/src/components/video_overlay/_video_overlay.scss
@@ -56,25 +56,6 @@
       }
     }
   }
-
-  .video-js {
-    margin: 0 auto;
-  }
-
-  .vjs-play-progress {
-    background-color: $lpblue;
-  }
-
-  .vjs-volume-level {
-    background-color: $lpblue;
-  }
-
-  .vjs-big-play-button {
-    &:hover,
-    &:active {
-      background-color: $lpblue;
-    }
-  }
 }
 
 

--- a/src/components/video_overlay/video_overlay.hbs
+++ b/src/components/video_overlay/video_overlay.hbs
@@ -4,21 +4,7 @@
   </div>
   <div class="video-overlay__video">
     <div class="video-overlay__video__container">
-      <!--<video
-        data-account="5104226627001" 
-        data-player="default" 
-        data-embed="default" 
-        class="video-js" 
-        controls></video>
-      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>--> 
-       <div style="display: block; position: relative; max-width: 100%;"><div style="padding-top: 100%;"><video data-account="5104226627001" 
-        data-player="SyiWdiOZl" 
-        data-embed="default" 
-        data-application-id 
-        class="video-js" 
-        controls 
-        style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;"></video>
-        <script src="//players.brightcove.net/5104226627001/SyiWdiOZl_default/index.min.js"></script></div></div> 
+      <!-- Load video embed dynamically here -->
     </div>
   </div>
 </div>

--- a/src/components/video_overlay/video_overlay.hbs
+++ b/src/components/video_overlay/video_overlay.hbs
@@ -4,13 +4,21 @@
   </div>
   <div class="video-overlay__video">
     <div class="video-overlay__video__container">
-      <video
+      <!--<video
         data-account="5104226627001" 
         data-player="default" 
         data-embed="default" 
         class="video-js" 
         controls></video>
-      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script> 
+      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>--> 
+       <div style="display: block; position: relative; max-width: 100%;"><div style="padding-top: 100%;"><video data-account="5104226627001" 
+        data-player="SyiWdiOZl" 
+        data-embed="default" 
+        data-application-id 
+        class="video-js" 
+        controls 
+        style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;"></video>
+        <script src="//players.brightcove.net/5104226627001/SyiWdiOZl_default/index.min.js"></script></div></div> 
     </div>
   </div>
 </div>

--- a/src/components/video_overlay/video_overlay.hbs
+++ b/src/components/video_overlay/video_overlay.hbs
@@ -4,7 +4,14 @@
   </div>
   <div class="video-overlay__video">
     <div class="video-overlay__video__container">
-      <!-- Load video embed dynamically here -->
+      <video data-account="5104226627001" 
+        data-player="default" 
+        data-embed="default" 
+        data-application-id 
+        class="video-js" 
+        controls >
+      </video>
+      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
     </div>
   </div>
 </div>

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -50,49 +50,16 @@ export default class VideoOverlay extends Overlay {
       return;
     }
 
-    let ratio = this.defaultAspectRatio;
-
-    // If we have video data, use the aspect ratio of the 
-    // video as the width-height ratio value
-    try {
-      let source = this.player.player.mediainfo.rawSources[0];
-      ratio = source.width / source.height;
-    }
-    catch (e) {}
-
     let maxHeight = $(window).innerHeight() - this.$el.find(".video-overlay__close").outerHeight();
     let maxWidth = $(".lp-global-header__container").innerWidth();
     let containerWidth = this.$el.find(".video-overlay__video__container").innerWidth();
     if (maxWidth > containerWidth) {
       maxWidth = containerWidth;
     }
-    let width = maxWidth;
-    let height = width / ratio;
 
-    if (height > maxHeight) {
-      height = maxHeight;
-      width = height * ratio;
-    }
+    let ideal = this.player.getIdealDimensions(maxWidth, maxHeight);
 
-    $(this.player.videoEl).css({ width: width, height: height });
-  }
-
-  /**
-  * Used to set the initial dimensions of the video player
-  * so that when video data begins to load, it sees that the player is fairly
-  * large and loads high-res video data.  We have an issue with Brightcove at the moment
-  * where it seems to load lower-res video if the player size is set to "mobile-like" 
-  * dimensions, but we want to make sure we always have high-res video loaded (if available).
-  */
-  setInitialDimensions () {
-    if (!this.player) {
-      return;
-    }
-
-    let width = 1280;
-    let height = width / this.defaultAspectRatio;
-
-    $(this.player.videoEl).css({ width: width, height: height});
+    $(this.player.videoEl).css({ width: ideal.width, height: ideal.height });
   }
 
   /**
@@ -101,9 +68,6 @@ export default class VideoOverlay extends Overlay {
   */
   playerReady (player) {
     this.player = player;
-
-    this.setInitialDimensions();
-
     this.player.search().then(this.searchDone.bind(this));
   }
 

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -10,7 +10,6 @@ export default class VideoOverlay extends Overlay {
   initialize (options) {
     super.initialize(options);
 
-    this.defaultAspectRatio = 1.77777778;
     this.resizeBound = false;
 
     Video.addPlayer(this.el, "brightcove").then(this.playerReady.bind(this));
@@ -64,27 +63,16 @@ export default class VideoOverlay extends Overlay {
 
   /**
   * Callback from the player "ready" event
-  * @param  {VideoPlayer} player Instance of the VideoPlayer
+  * @param  {VideoPlayer} player - Instance of the VideoPlayer
   */
   playerReady (player) {
     this.player = player;
-    this.player.search().then(this.searchDone.bind(this));
-  }
-
-  /**
-  * Callback from the player search()
-  * @param  {videos} list of video ids that matched the search
-  */
-  searchDone (videos) {
-    if (videos.length) {
-      let videoId = videos[0];
-      this.player.loadVideo(videoId).then(this.loadDone.bind(this));
-    }
+    this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
   }
 
   /**
   * Callback from the player loadVideo()
-  * @param  {success} bool depicting whether the video successfully loaded or not
+  * @param  {bool} success - depicting whether the video successfully loaded or not
   */
   loadDone (success) {
     if (!success) {

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -13,11 +13,11 @@
   }
 
   &__container {
+    left: 0;
+    max-width: 1280px;
     position: relative;
     top: 0;
-    left: 0;
     width: 100%;
-    max-width: 1280px;
   }
 
   &__video {
@@ -39,10 +39,10 @@
   &__inner {
     color: $color-white;
     display: block;
-    letter-spacing: -0.31px;
-    position: relative;
+    letter-spacing: -.31px;
     opacity: 0;
     overflow: hidden;
+    position: relative;
     transition: opacity $animation-speed-ui ease-in-out;
     z-index: -20;
 
@@ -53,18 +53,19 @@
   }
 
   &__backdrop {
-    position: absolute;
-    width: 100%;
-    height: 100%;
+    background-image: linear-gradient(-180deg, transparent 2%, rgba($color-black, 1) 98%);
     bottom: 0;
+    height: 100%;
     left: 0;
     opacity: .47;
-    background-image: linear-gradient(-180deg, transparent 2%, rgba(0, 0, 0, 1) 98%);
+    position: absolute;
     transition: opacity ($animation-speed-ui / 2) ease;
+    width: 100%;
   }
 
   &__text {
     align-items: center;
+    bottom: 0;
     display: flex;
     justify-content: center;
     left: 0;
@@ -72,10 +73,7 @@
     padding: 11rem 7rem 7rem;
     position: absolute;
     text-align: center;
-    bottom: 0;
     width: 100%;
-    
-    line-height: 20px;
 
     @media (max-width: $max-720) {
       padding: 5rem 3rem 4rem;
@@ -84,7 +82,6 @@
     @media (max-width: $max-480) {
       padding: 4rem 2rem 2rem;
     }
-
   }
 
   &__text__inner {
@@ -92,6 +89,7 @@
   }
 
   &__play {
+    background-color: $lpblue;
     border-radius: 50%;
     display: inline-block;
     font-size: 2.4rem;
@@ -100,7 +98,6 @@
     padding-top: 1.85rem;
     text-align: center;
     width: 6rem;
-    background-color: $lpblue;
 
     @media (max-width: $max-720) {
       font-size: 2.1rem;
@@ -111,11 +108,11 @@
     }
 
     @media (max-width: $max-560) {
-      width: 4rem;
-      height: 4rem;
       font-size: 1.9rem;
-      padding-top: 1.025rem;
-      padding-left: 0.6rem;
+      height: 4rem;
+      padding-left: .5rem;
+      padding-top: 1.05rem;
+      width: 4rem;
     }
 
     @media (max-width: $max-480) {
@@ -151,7 +148,6 @@
 
   &__description {
     font-size: 1.2rem;
-    line-height: 1.9em;
     padding: 2.8em 20%;
 
     @media (max-width: $max-720) {

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -39,8 +39,10 @@
   &__inner {
     color: $color-white;
     display: block;
+    letter-spacing: -0.31px;
     position: relative;
     opacity: 0;
+    overflow: hidden;
     transition: opacity $animation-speed-ui ease-in-out;
     z-index: -20;
 
@@ -50,85 +52,122 @@
     }
   }
 
+  &__backdrop {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    bottom: 0;
+    left: 0;
+    opacity: .47;
+    background-image: linear-gradient(-180deg, transparent 2%, rgba(0, 0, 0, 1) 98%);
+    transition: opacity ($animation-speed-ui / 2) ease;
+  }
+
   &__text {
     align-items: center;
-    background-color: rgba($color-black, .1);
     display: flex;
-    height: 100%;
     justify-content: center;
     left: 0;
     overflow: hidden;
-    padding: $gutter * 2;
+    padding: 11rem 7rem 7rem;
     position: absolute;
     text-align: center;
-    top: 0;
-    transition: background-color ($animation-speed-ui / 2) ease;
+    bottom: 0;
     width: 100%;
+    
+    line-height: 20px;
 
     @media (max-width: $max-720) {
-      padding: $gutter;
+      padding: 5rem 3rem 4rem;
     }
 
     @media (max-width: $max-480) {
-      padding: $gutter / 2;
+      padding: 4rem 2rem 2rem;
     }
+
+  }
+
+  &__text__inner {
+    z-index: 1;
   }
 
   &__play {
-    border: .2rem solid $color-white;
     border-radius: 50%;
     display: inline-block;
-    font-size: 3rem;
+    font-size: 2.4rem;
     height: 6rem;
-    padding-left: .7rem;
-    padding-top: 1.4rem;
+    padding-left: .65rem;
+    padding-top: 1.85rem;
     text-align: center;
     width: 6rem;
+    background-color: $lpblue;
 
-    @media (max-width: $max-560) {
+    @media (max-width: $max-720) {
       font-size: 2.1rem;
       height: 4.5rem;
-      padding-left: .5rem;
-      padding-top: 1rem;
+      padding-left: .6rem;
+      padding-top: 1.2rem;
       width: 4.5rem;
+    }
+
+    @media (max-width: $max-560) {
+      width: 4rem;
+      height: 4rem;
+      font-size: 1.9rem;
+      padding-top: 1.025rem;
+      padding-left: 0.6rem;
     }
 
     @media (max-width: $max-480) {
       font-size: 1.8rem;
       height: 3.7rem;
       padding-left: .45rem;
-      padding-top: .8rem;
+      padding-top: .9rem;
       width: 3.7rem;
     }
   }
 
   &__title {
     font-family: $benton-sans;
-    font-size: 4rem;
+    font-size: 2.4rem;
     font-weight: 400;
     margin-top: $gutter;
-    text-transform: uppercase;
 
     @media (max-width: $max-720) {
-      font-size: 2.75rem;
+      font-size: 2.1rem;
       margin-top: $gutter / 1.5;
     }
 
     @media (max-width: $max-480) {
-      font-size: 2.1rem;
-      margin-top: $gutter / 2;
+      font-size: 1.9rem;
+      margin-top: $gutter / 2.5;
+    }
+
+    @media (max-width: $max-320) {
+      font-size: 1.7rem;
+      margin-top: $gutter / 2.5;
+    }
+  }
+
+  &__description {
+    font-size: 1.2rem;
+    line-height: 1.9em;
+    padding: 2.8em 20%;
+
+    @media (max-width: $max-720) {
+      padding: 2.2em 12%;
     }
 
     @media (max-width: $max-360) {
-      font-size: 1.9rem;
-      margin-top: $gutter / 2.5;
+      font-size: 1.1rem;
+      padding: 2em;
     }
   }
 }
 
 .video-poster-button__inner:hover {
 
-  .video-poster-button__text {
-    background-color: rgba($color-black, .17);
+  .video-poster-button__backdrop {
+    opacity: .56;
   }
 }

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -12,15 +12,42 @@
     opacity: 1;
   }
 
-  &__inner {
-    color: $color-white;
-    display: inline-block;
+  &__container {
     position: relative;
+    top: 0;
+    left: 0;
+    width: 100%;
+    max-width: 1280px;
   }
 
-  &__poster {
-    max-width: 890px;
+  &__video {
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    transition: opacity $animation-speed-ui ease-in-out;
     width: 100%;
+    z-index: -20;
+
+    &--visible {
+      opacity: 1;
+      z-index: 0;
+    }
+  }
+
+  &__inner {
+    color: $color-white;
+    display: block;
+    position: relative;
+    opacity: 0;
+    transition: opacity $animation-speed-ui ease-in-out;
+    z-index: -20;
+
+    &--visible {
+      opacity: 1;
+      z-index: 0;
+    }
   }
 
   &__text {

--- a/src/components/video_poster_button/index.js
+++ b/src/components/video_poster_button/index.js
@@ -1,6 +1,5 @@
 import VideoPosterButtonComponent from "./video_poster_button_component";
 
 require("./_video_poster_button.scss");
-require("../video/_video.scss");
 
 export default VideoPosterButtonComponent;

--- a/src/components/video_poster_button/index.js
+++ b/src/components/video_poster_button/index.js
@@ -1,5 +1,6 @@
 import VideoPosterButtonComponent from "./video_poster_button_component";
 
 require("./_video_poster_button.scss");
+require("../video/_video.scss");
 
 export default VideoPosterButtonComponent;

--- a/src/components/video_poster_button/video_poster_button.hbs
+++ b/src/components/video_poster_button/video_poster_button.hbs
@@ -1,14 +1,33 @@
 <div class="video-poster-button segment">
     <div class="container">
-        <a class="video-poster-button__inner" href="">
-            <img class="video-poster-button__poster" />
-            <div class="video-poster-button__text">
-                <div class="video-poster-button__text__inner">
-                    <i class="video-poster-button__play icon-play3"></i>
-                    <div class="video-poster-button__title">
+        <div class="video-poster-button__container">
+            <a class="video-poster-button__inner video-poster-button__inner--visible" href="">
+                <img class="video-poster-button__poster" />
+                <div class="video-poster-button__text">
+                    <div class="video-poster-button__text__inner">
+                        <i class="video-poster-button__play icon-play3"></i>
+                        <div class="video-poster-button__title">
+                        </div>
                     </div>
                 </div>
+            </a>
+            <div class="video-poster-button__video">
+                {{! begin brightcove embed code }}
+                <!--<div style="display: block; position: relative; max-width: 100%;">
+                    <div style="padding-top: 100%;">-->
+                        <video data-account="5104226627001" 
+                            data-player="default" 
+                            data-embed="default" 
+                            data-application-id 
+                            class="video-js" 
+                            controls 
+                            style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;">
+                        </video>
+                        <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
+                    <!--</div>
+                </div> -->
+                {{! end brightcove embed code }}
             </div>
-        </a>
+        </div>
     </div>
 </div>

--- a/src/components/video_poster_button/video_poster_button.hbs
+++ b/src/components/video_poster_button/video_poster_button.hbs
@@ -4,6 +4,8 @@
             <a class="video-poster-button__inner video-poster-button__inner--visible" href="">
                 <img class="video-poster-button__poster" />
                 <div class="video-poster-button__text">
+                    <div class="video-poster-button__backdrop">
+                    </div>
                     <div class="video-poster-button__text__inner">
                         <i class="video-poster-button__play icon-play3"></i>
                         <div class="video-poster-button__title">
@@ -12,22 +14,17 @@
                 </div>
             </a>
             <div class="video-poster-button__video">
-                {{! begin brightcove embed code }}
-                <!--<div style="display: block; position: relative; max-width: 100%;">
-                    <div style="padding-top: 100%;">-->
-                        <video data-account="5104226627001" 
-                            data-player="default" 
-                            data-embed="default" 
-                            data-application-id 
-                            class="video-js" 
-                            controls 
-                            style="width: 100%; height: 100%; position: absolute; top: 0px; bottom: 0px; right: 0px; left: 0px;">
-                        </video>
-                        <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
-                    <!--</div>
-                </div> -->
-                {{! end brightcove embed code }}
+                <video data-account="5104226627001" 
+                    data-player="default" 
+                    data-embed="default" 
+                    data-application-id 
+                    class="video-js" 
+                    controls >
+                </video>
+                <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
             </div>
+        </div>
+        <div class="video-poster-button__description">
         </div>
     </div>
 </div>

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -1,53 +1,103 @@
 import { Component } from "../../core/bane";
-import VideoOverlay from "../video_overlay";
+import Video from "../video";
 
 /**
  * Video Poster Button Component
 */
 export default class VideoPosterButtonComponent extends Component {
-    initialize () {
-        this.overlay = new VideoOverlay({el: ".video-overlay"});
+  initialize () {
 
-        this.events = {
-            "click .video-poster-button__inner": "onClick"
-        };
+    this.playerVisible = false;
 
-        this.listenTo(this.overlay, "video.loaded", this.onVideoLoaded);
+    this.events = {
+        "click .video-poster-button__inner": "onClick"
+    };
+
+    Video.addPlayer(this.el, "brightcove").then(this.playerReady.bind(this));
+
+  }
+
+  showVideo () {
+    if (this.playerVisible) {
+      return;
+    }
+    this.playerVisible = true;
+
+    let buttonContainer = this.$el.find(".video-poster-button__inner");
+    buttonContainer.removeClass("video-poster-button__inner--visible");
+
+    let videoContainer = this.$el.find(".video-poster-button__video");
+    videoContainer.addClass("video-poster-button__video--visible");
+
+    this.player.play();
+  }
+
+  hideVideo () {
+    if (!this.playerVisible) {
+      return;
+    }
+    this.playerVisible = false;
+
+    this.player.pause();
+
+    let buttonContainer = this.$el.find(".video-poster-button__inner");
+    buttonContainer.addClass("video-poster-button__inner--visible");
+
+    let videoContainer = this.$el.find(".video-poster-button__video");
+    videoContainer.removeClass("video-poster-button__video--visible");
+  }
+
+  render () {
+    let title = "";
+    let image = null;
+
+    try {
+        let mediainfo = this.player.player.mediainfo;
+        title = mediainfo.name;
+        image = mediainfo.poster;
+    }
+    catch (e) {
     }
 
-    render () {
-        let title = "";
-        let image = null;
-
-        try {
-            let mediainfo = this.overlay.player.player.mediainfo;
-            title = mediainfo.name;
-            image = mediainfo.poster;
-        }
-        catch (e) {
-        }
-
-        if (!image) {
-            this.$el.removeClass("video-poster-button--visible");
-        }
-
-        let imageEl = this.$el.find(".video-poster-button__poster")[0];
-        imageEl.onload = () => {
-            this.$el.addClass("video-poster-button--visible");
-        };
-        imageEl.src = image;
-
-        this.$el.find(".video-poster-button__title").text(title);
-
-        return this;
+    if (!image) {
+        this.$el.removeClass("video-poster-button--visible");
     }
 
-    onClick (e) {
-        e.preventDefault();
-        this.overlay.show();
+    let imageEl = this.$el.find(".video-poster-button__poster")[0];
+    imageEl.onload = () => {
+      $(this.player.videoEl).css({ width: "100%", height: "100%" });
+      this.$el.addClass("video-poster-button--visible");
+    };
+    imageEl.src = image;
+
+    this.$el.find(".video-poster-button__title").text(title);
+
+    return this;
+  }
+
+  onClick (e) {
+    e.preventDefault();
+    this.showVideo();
+  }
+
+  /**
+    * Callback from the player "ready" event
+    * @param  {VideoPlayer} player Instance of the VideoPlayer
+    */
+  playerReady (player) {
+    this.player = player;
+    this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
+  }
+
+  /**
+  * Callback from the player searchAndLoadVideo()
+  * @param  {success} bool depicting whether a video successfully loaded or not
+  */
+  loadDone (success) {
+    if (!success) {
+      return;
     }
 
-    onVideoLoaded () {
-        this.render();
-    }
+    this.render();
+  }
 }

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -14,7 +14,6 @@ export default class VideoPosterButtonComponent extends Component {
     };
 
     Video.addPlayer(this.el, "brightcove").then(this.playerReady.bind(this));
-
   }
 
   showVideo () {
@@ -54,9 +53,9 @@ export default class VideoPosterButtonComponent extends Component {
 
     try {
         let mediainfo = this.player.player.mediainfo;
-        title = mediainfo.name;
+        title = mediainfo.name || "";
         image = mediainfo.poster;
-        description = mediainfo.description;
+        description = mediainfo.description || "";
     }
     catch (e) {
     }
@@ -67,16 +66,17 @@ export default class VideoPosterButtonComponent extends Component {
 
     let imageEl = this.$el.find(".video-poster-button__poster")[0];
     imageEl.onload = () => {
+
+      // Reset the width and height of the player to be the same 
+      // dimensions as the poster image so that we have a nice 
+      // smooth transition (and to undo Brightcove.setInitialDimensions())
       $(this.player.videoEl).css({ width: "100%", height: "100%" });
+
       this.$el.addClass("video-poster-button--visible");
     };
     imageEl.src = image;
 
     this.$el.find(".video-poster-button__title").text(title);
-
-    // TEMP
-    description = "Test Description goes here.  Check out Ireland!  You think you can just be part of the team whenever you want? You gotta work for it!  and travel ;)";
-
     this.$el.find(".video-poster-button__description").text(description);
 
     return this;
@@ -93,7 +93,15 @@ export default class VideoPosterButtonComponent extends Component {
     */
   playerReady (player) {
     this.player = player;
+    this.listenTo(this.player, "ended", this.onVideoEnded.bind(this));
     this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
+  }
+
+  /**
+   * Callback from the player "ended" event / when a video finishes playing.
+   */
+  onVideoEnded () {
+    this.hideVideo();
   }
 
   /**

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -50,11 +50,13 @@ export default class VideoPosterButtonComponent extends Component {
   render () {
     let title = "";
     let image = null;
+    let description = "";
 
     try {
         let mediainfo = this.player.player.mediainfo;
         title = mediainfo.name;
         image = mediainfo.poster;
+        description = mediainfo.description;
     }
     catch (e) {
     }
@@ -72,6 +74,11 @@ export default class VideoPosterButtonComponent extends Component {
 
     this.$el.find(".video-poster-button__title").text(title);
 
+    // TEMP
+    description = "Test Description goes here.  Check out Ireland!  You think you can just be part of the team whenever you want? You gotta work for it!  and travel ;)";
+
+    this.$el.find(".video-poster-button__description").text(description);
+
     return this;
   }
 
@@ -82,7 +89,7 @@ export default class VideoPosterButtonComponent extends Component {
 
   /**
     * Callback from the player "ready" event
-    * @param  {VideoPlayer} player Instance of the VideoPlayer
+    * @param  {VideoPlayer} player - Instance of the VideoPlayer
     */
   playerReady (player) {
     this.player = player;
@@ -91,7 +98,7 @@ export default class VideoPosterButtonComponent extends Component {
 
   /**
   * Callback from the player searchAndLoadVideo()
-  * @param  {success} bool depicting whether a video successfully loaded or not
+  * @param  {bool} success - depicting whether a video successfully loaded or not
   */
   loadDone (success) {
     if (!success) {


### PR DESCRIPTION
- Updated styling on Video Poster Button (Blue play icon design)
- Moved videojs specific CSS to it's own file
- Moved common logic to resize video player into Brightcove.js as it is used by both "Video Poster Button" and "Video Overlay"
- Brightcove player now resizes itself when it's initially loaded to ensure high res video content is loaded
- Brightcove player now automatically inserts LD-JSON (Schema.org) markup into page head tag when any video is loaded into the player.
- Added "ended" event emitted from Brightcove.js player.  Video Poster Button listens to this to know when the video ends and the poster image can be placed back on the page.