### PR TITLE
Update mapbox-js to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "jquery": "^2.1.4",
     "jquery.dfp": "^2.4.1",
     "lodash": "^3.10.0",
-    "mapbox.js": "^2.2.2",
+    "mapbox.js": "^3.0.1",
     "mapbox-gl": "^0.19.0",
     "matchmedia-polyfill": "^0.3.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Hope to fix an error (`Octal literal in strict mode`) when trying to publish the module to NPM.