### PR TITLE
Fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "ci": "karma start",
-    "build": "rimraf dist && mkdir -p dist/header_normal && node bin/rizzo build && node bin/rizzo build -c ../lib/data/header_normal.json",
+    "build": "rimraf dist && mkdir -p dist/header_normal && node bin/rizzo build -c ../lib/data/header_normal.json && node bin/rizzo build",
     "docs": "node-sass sass/docs.scss -o dist/css --include-path=node_modules && esdoc -c esdoc.json",
     "sassdoc": "./node_modules/.bin/sassdoc sass --theme neat",
     "lint": "./node_modules/.bin/eslint src --ext .js,.jsx",


### PR DESCRIPTION
This highlights a bigger issue which is that the header build process desperately needs to be updated.

When the `node bin/rizzo build -c ../lib/data/header_normal.json` was added to `npm run build`, it was added after the original `node bin/rizzo build`. This was causing the `rizzo-next.js` file to only contain the constructors listed in... https://github.com/lonelyplanet/rizzo-next/blob/master/lib/data/header_normal.json.

The build process for the header was a bandaid for getting us a global nav and we need to pay down that technical debt.