### PR TITLE
fix hanging getCurrentPosition in firefox

### DIFF
--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -20,14 +20,23 @@ class MapComponent extends Component {
       return false;
     }
 
+    let geolocationTimeout = 10000;
+    let getCurrentPositionCompleted = false;
+    setTimeout(() => {
+      if(!getCurrentPositionCompleted){
+        this.fetchMap();
+      }
+    }, geolocationTimeout + 1000);
+
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
+        getCurrentPositionCompleted = true;
         this.userLocation = [position.coords.latitude, position.coords.longitude];
-
         this.fetchMap();
       }, () => {
+        getCurrentPositionCompleted = true;
         this.fetchMap();
-      });
+      },{timeout: geolocationTimeout});
     }
 
     Arkham.on("map.closed", () => {


### PR DESCRIPTION
request: https://trello.com/c/jxXYupYG/139-map-view-not-working-if-location-isn-t-shared
This is workaround for weird ff behaviour - clicking "Not Now" hangs `getCurrentPosition` method (more info: https://bugzilla.mozilla.org/show_bug.cgi?id=675533).