### PR TITLE
get closest feature manually in case queryRenderedFeatures throws error

### DIFF
--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -200,7 +200,7 @@ class MarkerSet extends Component {
         minIndex = i;
       }
     }
-    if (minDistance < 1) {
+    if (minDistance < (20 - this.map.getZoom())/10) {
       return [(this.pois[minIndex]).geo];
     } else {
       return [];

--- a/src/components/map/mapbox/markerset.js
+++ b/src/components/map/mapbox/markerset.js
@@ -142,7 +142,12 @@ class MarkerSet extends Component {
   }
 
   _poiHover(e) {
-    const features = this.map.queryRenderedFeatures(e.point, { layers: ["markers"] });
+    let features;
+    try {
+      features = this.map.queryRenderedFeatures(e.point, { layers: ["markers"] });
+    } catch(error) {
+      features = this._getClosestFeatures(e.lngLat.lng, e.lngLat.lat);
+    }
 
     if (!features.length) {
         this.popup.remove();
@@ -167,6 +172,39 @@ class MarkerSet extends Component {
       .addTo(this.map);
 
     MapActions.itemHighlight(feature.properties.index);
+  }
+
+  _toRadians(deg) {
+    return deg * Math.PI / 180;
+  }
+
+  _equirectangularDistance(lng1, lat1, lng2, lat2) {
+    let x = (lng1 - lng2) * Math.cos((lat1 + lat2)/2);
+    let y = (lat1 - lat2);
+    return (Math.sqrt(x*x + y*y) * 6371);
+  }
+
+  _getClosestFeatures(lng1, lat1) {
+    let minDistance = 1000000;
+    let minIndex = 0;
+    lng1 = this._toRadians(lng1);
+    lat1 = this._toRadians(lat1);
+    for (let i = 0, l = this.pois.length; i < l; i++) {
+      let geo = this.pois[i].geo;
+      let lng2 = this._toRadians(geo.geometry.coordinates[0]);
+      let lat2 = this._toRadians(geo.geometry.coordinates[1]);
+      let distance = this._equirectangularDistance(lng1, lat1, lng2, lat2);
+
+      if (distance < minDistance) {
+        minDistance = distance;
+        minIndex = i;
+      }
+    }
+    if (minDistance < 1) {
+      return [(this.pois[minIndex]).geo];
+    } else {
+      return [];
+    }
   }
 
   _poiClick(event) {


### PR DESCRIPTION
request: https://trello.com/c/TkQTYjLX/121-map-on-london-destination-page-doesn-t-work-properly-you-can-t-click-on-the-icon-on-the-map-to-bring-up-the-name-of-the-place

Sometimes, for maps of big cities (London, Mexico City etc.), when there is a lot of markers in one place mapbox-gl-js' `queryRenderedFeatures` method throws `Caught: Unimplemented type: 7`. I implemented workaround for this case - getting closest feature/poi manually. `_getClosestFeatures` takes longitude and latitude of current cursor position, calculates equirectangular projection distance for all markers and returns the closest one or nothing if calculated minimal distance is too long.