### PR TITLE
360 Video support for video-based components

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": "npm run build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
   },
-  "version": "0.11.95",
+  "version": "0.11.96",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "prepublish": "npm run build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
   },
-  "version": "0.11.92",
+  "version": "0.11.95",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -91,8 +91,7 @@ class Brightcove extends VideoPlayer {
   search() {
     return new Promise((resolve) => {
       try {
-        // let refId = "dest_" + window.lp.place.atlasId;
-        let refId = "360_CA_van";
+        let refId = "dest_" + window.lp.place.atlasId;
         let url = "https://edge.api.brightcove.com/playback/v1/accounts/" + this.accountId + "/videos/ref:" + refId;
         let accept = "application/json;pk=" + this.policyKey;
 

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -24,6 +24,10 @@ class Video {
     // Take the return value and use .then() on it to ensure the 
     // player is ready before using it.
     return new Promise((resolve) => {
+      if (player.ready) {
+        resolve(player);
+        return;
+      }
       player.on("ready", () => {
         resolve(player);
       });

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -1,11 +1,17 @@
 import { Component } from "../../core/bane";
+import MobilUtil from "../../core/mobile_util";
 
 class VideoPlayer extends Component {
 
   initialize({ playerId }) {
     this.playerId = playerId;
+
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
+
+    this.ready = false;
+    this.on("ready", () => { this.ready = true; });
+    
     this.setup();
   }
 
@@ -27,6 +33,44 @@ class VideoPlayer extends Component {
    * Override to actually pause the underlying player
    */
   pause() {
+  }
+
+  /**
+   * Determines whether 360 Video is supported on the current device.
+   * 
+   * references: 
+   *   https://gist.github.com/dhinus/909b1530d2b30681edf7
+   *   http://www.useragentstring.com/pages/useragentstring.php
+   *
+   */
+  is360VideoSupported() {
+    if (MobilUtil.isMobileOrTablet()) {
+      return false;
+    }
+
+    let ua = navigator.userAgent || navigator.vendor || window.opera;
+
+    // Chrome >= 40
+    if (/Chrome\/[^123][0-9]/.test(ua) && !/Edge\//.test(ua) && !/OPR\//.test(ua)) {
+      return true;
+    }
+
+    // Firefox >= 40
+    if (/Firefox\/[^123][0-9]/.test(ua)) {
+      return true;
+    }
+
+    // Microsoft Edge
+    if (/Edge\//.test(ua)) {
+      return true;
+    }
+
+    // Opera >= 30 (Opera 12 and lower used "Opera" in the user agent string, but new versions use "OPR")
+    if (/OPR\/[^12][0-9]/.test(ua)) {
+      return true;
+    }
+
+    return false;
   }
 
 }

--- a/src/components/video_overlay/video_overlay.hbs
+++ b/src/components/video_overlay/video_overlay.hbs
@@ -4,14 +4,6 @@
   </div>
   <div class="video-overlay__video">
     <div class="video-overlay__video__container">
-      <video data-account="5104226627001" 
-        data-player="default" 
-        data-embed="default" 
-        data-application-id 
-        class="video-js" 
-        controls >
-      </video>
-      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
     </div>
   </div>
 </div>

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -67,7 +67,32 @@ export default class VideoOverlay extends Overlay {
   */
   playerReady (player) {
     this.player = player;
-    this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
+    this.player.search().then(this.searchDone.bind(this));
+  }
+
+  /**
+  * Callback from the player search()
+  * @param  {bool} success - depicting whether a video successfully loaded or not
+  */
+  searchDone (data) {
+    if (data.length) {
+      let videoId = data[0].id;
+
+      // If this is a 360 video and the user is using an incapatible device, just stop.
+      if (this.player.is360Video(videoId) && !this.player.is360VideoSupported()) {
+        return;
+      }
+
+      let videoContainer = this.$el.find(".video-overlay__video__container")[0];
+
+      // Insert the player embed, load the video, and then run this.loadDone when finished.
+      (this.player
+        .insertPlayer(videoContainer, videoId)
+        .then(() => {
+          return this.player.loadVideo(videoId);
+        })
+        .then(this.loadDone.bind(this)));
+    }
   }
 
   /**

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -38,7 +38,6 @@
 
   &__inner {
     color: $color-white;
-    // display: inline-block;
     float: left;
     letter-spacing: -.31px;
     opacity: 0;

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -13,11 +13,11 @@
   }
 
   &__container {
+    display: inline-block;
     left: 0;
-    max-width: 1280px;
     position: relative;
     top: 0;
-    width: 100%;
+    margin: 0 auto;
   }
 
   &__video {
@@ -38,7 +38,8 @@
 
   &__inner {
     color: $color-white;
-    display: block;
+    // display: inline-block;
+    float: left;
     letter-spacing: -.31px;
     opacity: 0;
     overflow: hidden;

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -15,9 +15,9 @@
   &__container {
     display: inline-block;
     left: 0;
+    margin: 0 auto;
     position: relative;
     top: 0;
-    margin: 0 auto;
   }
 
   &__video {

--- a/src/components/video_poster_button/video_poster_button.hbs
+++ b/src/components/video_poster_button/video_poster_button.hbs
@@ -14,14 +14,7 @@
                 </div>
             </a>
             <div class="video-poster-button__video">
-                <video data-account="5104226627001" 
-                    data-player="default" 
-                    data-embed="default" 
-                    data-application-id 
-                    class="video-js" 
-                    controls >
-                </video>
-                <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
+                <!-- Video will be dynamically inserted here -->
             </div>
         </div>
         <div class="video-poster-button__description">

--- a/src/components/video_poster_button/video_poster_button.hbs
+++ b/src/components/video_poster_button/video_poster_button.hbs
@@ -1,3 +1,4 @@
+
 <div class="video-poster-button segment">
     <div class="container">
         <div class="video-poster-button__container">

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -7,6 +7,13 @@ import Video from "../video";
 export default class VideoPosterButtonComponent extends Component {
   initialize () {
 
+    // Temporary: querystring parameter video=true needs to be
+    // used to get the poster button to appear.
+    this.show360Videos = true;
+    if (window.location.href.indexOf("360=true") == -1) {
+       this.show360Videos = false;
+    }
+
     this.playerVisible = false;
 
     this.events = {
@@ -125,6 +132,11 @@ export default class VideoPosterButtonComponent extends Component {
   searchDone (data) {
     if (data.length) {
       let videoId = data[0].id;
+
+      // Temporary: Don't show 360 videos until they've been tested and approved
+      if (this.player.is360Video(videoId) && !this.show360Videos) {
+        return;
+      }
 
       // If this is a 360 video and the user is using an incapatible device, just stop.
       if (this.player.is360Video(videoId) && !this.player.is360VideoSupported()) {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -66,18 +66,23 @@ export default class VideoPosterButtonComponent extends Component {
 
     let imageEl = this.$el.find(".video-poster-button__poster")[0];
     imageEl.onload = () => {
-
       // Reset the width and height of the player to be the same 
       // dimensions as the poster image so that we have a nice 
       // smooth transition (and to undo Brightcove.setInitialDimensions())
       $(this.player.videoEl).css({ width: "100%", height: "100%" });
-
+      
       this.$el.addClass("video-poster-button--visible");
     };
     imageEl.src = image;
 
     this.$el.find(".video-poster-button__title").text(title);
-    this.$el.find(".video-poster-button__description").text(description);
+
+    let descriptionEl = this.$el.find(".video-poster-button__description");
+    descriptionEl.text(description).show();
+    
+    if (!description) {
+      descriptionEl.hide();
+    }
 
     return this;
   }
@@ -94,7 +99,8 @@ export default class VideoPosterButtonComponent extends Component {
   playerReady (player) {
     this.player = player;
     this.listenTo(this.player, "ended", this.onVideoEnded.bind(this));
-    this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
+    this.player.search().then(this.searchDone.bind(this));
+    // this.player.searchAndLoadVideo().then(this.loadDone.bind(this));
   }
 
   /**
@@ -105,9 +111,32 @@ export default class VideoPosterButtonComponent extends Component {
   }
 
   /**
-  * Callback from the player searchAndLoadVideo()
+  * Callback from the player search()
   * @param  {bool} success - depicting whether a video successfully loaded or not
   */
+  searchDone (data) {
+    if (data.length) {
+      let videoId = data[0].id;
+
+      if (this.player.is360Video(videoId) && !this.player.is360VideoSupported()) {
+        return;
+      }
+
+      let videoContainer = this.$el.find(".video-poster-button__video")[0];
+
+      (this.player
+        .insertPlayer(videoContainer, videoId)
+        .then(() => {
+          return this.player.loadVideo(videoId);
+        })
+        .then(this.loadDone.bind(this)));
+    }
+  }
+
+  /**
+   * Callback from the player searchAndLoadVideo()
+   * @param  {bool} success - depicting whether a video successfully loaded or not
+   */
   loadDone (success) {
     if (!success) {
       return;

--- a/src/core/mobile_util.js
+++ b/src/core/mobile_util.js
@@ -1,12 +1,30 @@
 "use strict";
 
 class MobileUtil {
+
   isMobile(userAgent) {
-    return this.checkUserAgent(userAgent || navigator.userAgent || navigator.vendor || window.opera);
+    userAgent = userAgent || navigator.userAgent || navigator.vendor || window.opera;
+    return this.checkUserAgent(userAgent, false);
   }
+
+  isMobileOrTablet(userAgent) {
+    userAgent = userAgent || navigator.userAgent || navigator.vendor || window.opera;
+    return this.checkUserAgent(userAgent, true);
+  }
+
   /** source http://detectmobilebrowsers.com **/
-  checkUserAgent(a){
-    return (/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino/i.test(a) || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test( a.substr(0, 4)));
+  checkUserAgent(a, tablet) {
+    let res1 = "(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od|ad)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino";
+    let res2 = "1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-";
+
+    if (tablet) {
+        res1 += "|android|ipad|playbook|silk";
+    }
+
+    let re1 = new RegExp(res1, "i");
+    let re2 = new RegExp(res2, "i");
+
+    return re1.test(a) || re2.test(a.substr(0, 4));
   }
 }
 


### PR DESCRIPTION
- Videos are queried via Brightcove's PlayList API instead of simply attempting to load them via an embed code and watching for failures (The API still returns a 404 if unable to find a video -- just like the embed code would) 
http://docs.brightcove.com/en/video-cloud/playback-api/getting-started/api-overview.html#methods

- Once a video is found, if it has a "360" tag on it, a 360 player embed code is dynamically loaded into the page.  Otherwise, the default 2D player is loaded dynamically.

- Brightcove component won't dynamically load an embed if it sees an embed code already on the page (within the component's parent element).

- Video embed no longer assumes it has the same dimensions as it's corresponding poster image.  They size themselves independently now.

- If a video is determined to be a 360 video on a browser that doesn't support 360 video, video components don't render, so the user won't even notice.