### PR TITLE
CSS Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "test": "karma start --single-run"
   },
-  "version": "0.12.8",
+  "version": "0.12.9",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/package.json
+++ b/package.json
@@ -15,14 +15,15 @@
     "name": "Lonely Planet"
   },
   "scripts": {
-    "test": "karma start --single-run",
+    "build": "rimraf dist && mkdir -p dist/header_normal && node bin/rizzo build -c ../lib/data/header_normal.json && node bin/rizzo build && npm run css",
     "ci": "karma start",
-    "build": "rimraf dist && mkdir -p dist/header_normal && node bin/rizzo build -c ../lib/data/header_normal.json && node bin/rizzo build",
+    "css": "node-sass sass/core.scss dist/core.css --include-path 'node_modules' --output-style compressed",
     "docs": "node-sass sass/docs.scss -o dist/css --include-path=node_modules && esdoc -c esdoc.json",
-    "sassdoc": "./node_modules/.bin/sassdoc sass --theme neat",
     "lint": "./node_modules/.bin/eslint src --ext .js,.jsx",
+    "prepublish": "npm run build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp",
+    "sassdoc": "./node_modules/.bin/sassdoc sass --theme neat",
     "scsslint": "scss-lint . --config .scss-lint.yml",
-    "prepublish": "npm run build && mkdir -p tmp && cp -R src/* tmp && babel -d tmp tmp && cp -R tmp/* dist && rimraf tmp"
+    "test": "karma start --single-run"
   },
   "version": "0.12.8",
   "pre-commit": [


### PR DESCRIPTION
Add a node-sass build for css.
Now we can just import the core.css file rather than building it in consuming applications.