### PR TITLE
Remove semi-colons from decorator calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "test": "karma start --single-run"
   },
-  "version": "0.12.11",
+  "version": "0.12.12",
   "pre-commit": [
     "scsslint",
     "lint"

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -48,7 +48,7 @@ export default class ArticleComponent extends Component {
     this.$globalFooter.detach();
   }
 
-  @subscribe("ad.loaded", "ads");
+  @subscribe("ad.loaded", "ads")
   _adsLoaded(data) {
     if (data.size === "leaderboard-responsive") {
       if (!this.hasAdTimeoutResolved) {

--- a/src/components/masthead/masthead_component.js
+++ b/src/components/masthead/masthead_component.js
@@ -54,7 +54,7 @@ export default class MastheadComponent extends Component {
     this.subscribe();
   }
 
-  @subscribe("ad.loaded", "ads");
+  @subscribe("ad.loaded", "ads")
   mastheadAdLoaded(data) {
     if (data.id === "sponsor-logo-masthead" || data.id === "best-in-badge-masthead") {
       let $mastheadAd = this.$el.find("#" + data.id);

--- a/src/components/sights/sights_component.js
+++ b/src/components/sights/sights_component.js
@@ -9,7 +9,7 @@ export default class Sights extends Component {
     this.subscribe();
   }
 
-  @subscribe("experiences.removed", "components");
+  @subscribe("experiences.removed", "components")
   _changeTitle() {
     this.$el.find(".js-sights-heading").toggleClass("sights__heading--large");
   }

--- a/src/components/sub_nav/index.js
+++ b/src/components/sub_nav/index.js
@@ -126,20 +126,20 @@ export default class SubNav extends Component {
       title: "Experiences"
     })).prependTo(this.$subNavList);
   }
-  @subscribe(RizzoEvents.LOAD_BELOW, "events");
+  @subscribe(RizzoEvents.LOAD_BELOW, "events")
   updateContentHeight() {
     this.contentHeight = $(".navigation-wrapper").outerHeight();
   }
   /**
    * If a component is removed from the DOM, this will remove its subnav element
    */
-  @subscribe("*.removed", "components");
+  @subscribe("*.removed", "components")
   removeSubNav(data, envelope) {
     let component = envelope.topic.split(".")[0];
 
     this.$el.find(`.sub-nav__item--${component}`).remove();
   }
-  @subscribe("experiences.removed", "components");
+  @subscribe("experiences.removed", "components")
   addSights() {
     if ($(".sights").length) {
       $(this.subNavItem({


### PR DESCRIPTION
Can't do that apparently... https://github.com/babel/babylon/pull/352