### PR TITLE
Change z-index of overlay

### DIFF
--- a/src/components/overlay/index.scss
+++ b/src/components/overlay/index.scss
@@ -9,7 +9,7 @@
   right: 0;
   top: 0;
   transition: opacity $animation-speed;
-  z-index: z("modal") - 2;
+  z-index: z("overlay");
 
   &--visible {
     opacity: 1;


### PR DESCRIPTION
Uses “overlay” value and places component below menus and modals.