### PR TITLE
Fix article ad, footer layout

### DIFF
--- a/src/components/article/article-header.scss
+++ b/src/components/article/article-header.scss
@@ -3,11 +3,6 @@
 .article-header {
   @include details-header();
 
-  .dfp-sponsor-badge {
-    @media(min-width: $min-600) {
-      margin-bottom: -2rem;
-    }
-  }
 
 
   // Implementation detail

--- a/src/components/article/article.scss
+++ b/src/components/article/article.scss
@@ -87,10 +87,9 @@
 }
 
 .article__footer {
-  @include container;
-  @include container-static(6);
   align-items: center;
   display: flex;
+  max-width: 63rem;
 
   .no-flexbox & {
     display: block;
@@ -102,17 +101,11 @@
 }
 
 .article__sponsor-ad {
-  @include container;
   font-size: 1.4rem;
   line-height: (22 / 14);
+  max-width: span(6 static);
   padding-bottom: .8rem;
   padding-top: .8rem;
-
-  @media(min-width: $min-720) {
-    @include with-layout(static) {
-      width: span(6);
-    }
-  }
 
 
 

--- a/src/components/article/article.scss
+++ b/src/components/article/article.scss
@@ -89,7 +89,7 @@
 .article__footer {
   align-items: center;
   display: flex;
-  max-width: 63rem;
+  max-width: span(6 static);
 
   .no-flexbox & {
     display: block;


### PR DESCRIPTION
Removes the container styles from the article ad and footer
to align them with the article body.