### PR TITLE
Change ID for sponsor ad

### DIFF
--- a/src/components/ads/ad_article_sponsor.hbs
+++ b/src/components/ads/ad_article_sponsor.hbs
@@ -1,7 +1,7 @@
 <div class="article__sponsor-ad js-article-sponsor-ad">
   {{#if adpackage}}
     <div
-      id="ad-articles-sponsor-logo"
+      id="ad-articles-sponsor"
       class="adunit adunit--sponsor-logo js-sponsor-logo"
       style="display: none;">
     </div>


### PR DESCRIPTION
Had two ad slots with the same ID `ad-articles-sponsor-logo`