### PR TITLE
Create unique IDs for article ads

### DIFF
--- a/src/components/ads/ad_article_leaderboard.hbs
+++ b/src/components/ads/ad_article_leaderboard.hbs
@@ -2,9 +2,8 @@
   <div class="ad--leaderboard__container">
     {{#if adpackage}}
       <div
-        id="ad-articles-leaderboard"
-        class="adunit adunit--leaderboard js-slot-leader"
-        style="display: none;">
+        id="ad-articles-leaderboard{{#if adSlotNumber}}-{{adSlotNumber}}{{/if}}"
+        class="adunit--leaderboard">
       </div>
     {{/if}}
 

--- a/src/components/ads/ad_article_sponsor.hbs
+++ b/src/components/ads/ad_article_sponsor.hbs
@@ -1,9 +1,8 @@
 <div class="article__sponsor-ad js-article-sponsor-ad">
   {{#if adpackage}}
     <div
-      id="ad-articles-sponsor"
-      class="adunit adunit--sponsor-logo js-sponsor-logo"
-      style="display: none;">
+      id="ad-articles-sponsor{{#if count}}-{{ count }}{{/if}}{{#unless count}}-1{{/unless}}"
+      class="adunit--sponsor-logo js-sponsor-logo">
     </div>
   {{/if}}
 

--- a/src/components/ads/ads.scss
+++ b/src/components/ads/ads.scss
@@ -63,6 +63,8 @@
 .ad--article .adunit--leaderboard {
   display: inline-block;
   margin-bottom: -8px; // offset `inline-block`
+  padding-bottom: 1.8rem;
+  padding-top: 1.8rem;
 }
 
 .attribution .adunit,

--- a/src/components/article/article.hbs
+++ b/src/components/article/article.hbs
@@ -16,9 +16,8 @@
 
             {{#if adpackage}}
               <div
-                id="ad-articles-sponsor-logo"
-                class="adunit adunit--sponsor-logo js-sponsor-logo"
-                style="display: none;">
+                id="ad-articles-sponsor-logo{{#if count}}-{{ count }}{{/if}}{{#unless count}}-1{{/unless}}"
+                class="adunit--sponsor-logo js-sponsor-logo">
               </div>
             {{/if}}
 

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -147,7 +147,8 @@ export default class ArticleComponent extends Component {
     }
 
     // Put the ad in the first article, but don't load it yet
-    this.$activeArticle.append(this.adLeaderboardTemplate({ adpackage }));
+    const adSlotNumber = this.howManyArticlesHaveLoaded;
+    this.$activeArticle.append(this.adLeaderboardTemplate({ adpackage, adSlotNumber }));
 
     if (adpackage) {
       this._insertInlineAdSlots(this.$el);
@@ -343,7 +344,8 @@ export default class ArticleComponent extends Component {
 
     return nextArticle.fetch().then(() => {
       this.$newArticle = $(this.template({
-        article: nextArticle.get()
+        article: nextArticle.get(),
+        count: (this.howManyArticlesHaveLoaded + 1)
       }))
       .appendTo(".page-container")
       .addClass("is-loading");
@@ -358,7 +360,8 @@ export default class ArticleComponent extends Component {
       this.$newArticle.attr("id", this._createIdForArticle(nextArticle.get().slug));
 
       // Put the ad in the new article, but don't load it yet
-      this.$newArticle.append(this.adLeaderboardTemplate({ adpackage }));
+      const adSlotNumber = this.howManyArticlesHaveLoaded;
+      this.$newArticle.append(this.adLeaderboardTemplate({ adpackage, adSlotNumber }));
 
       this._articleCanBeLoaded();
 

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -63,13 +63,22 @@
       }
 
       + p,
-      + .copy--body__list,
-      .adunit--articles-inline {
+      + .copy--body__list {
         margin-top: 1rem;
 
         @media (min-width: $min-600) {
           margin-top: 1.7em;
         }
+      }
+    }
+
+    .adunit--articles-inline {
+      margin-bottom: 1rem;
+      margin-top: 1rem;
+
+      @media (min-width: $min-600) {
+        margin-bottom: 1.7em;
+        margin-top: 1.7em;
       }
     }
 


### PR DESCRIPTION
Because of infinite scroll, ad slots within each article need a unique ID. The ad slots that have been updated are:

- leaderboard
- sponsor
- sponsor-logo

Removed `display: none` from ad slots; I think this was preventing some ads from being displayed and Google DFP doesn't seem to remove it like I thought it would.

Also added some CSS to fix some spacing issues with the in-content ads.

https://github.com/lonelyplanet/articles/issues/12