### PR TITLE
Update new yieldmo ad slot

### DIFF
--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -141,8 +141,7 @@ export default class ArticleBodyComponent extends Component {
   _appendAd($paragraphs, $featuredImage) {
     const element = adpackage ? `<div
       id="ad-articles-yieldmo"
-      class="adunit adunit--article"
-      style="display: none;"></div>` :
+      class="adunit--article"></div>` :
       `<div
         class="adunit adunit--article display-none"
         data-dfp-options='{ "namespace": "LonelyPlanet.com/Yieldmo" }'


### PR DESCRIPTION
- Remove `display: none`; DFP doesn’t remove this
- Remove `adunit` classname; this was a holdover from the jQuery DFP
implementation and the script still replaces any `div` with the
`adunit` classname

https://github.com/lonelyplanet/articles/issues/13