### PR TITLE
Fix up article ad slots

### DIFF
--- a/src/components/ads/ad_article_sponsor.hbs
+++ b/src/components/ads/ad_article_sponsor.hbs
@@ -1,15 +1,17 @@
-<div class="article__sponsor-ad js-article-sponsor-ad">
-  {{#if adpackage}}
+{{#if adpackage}}
+  <div class="article__sponsor-ad">
     <div
       id="ad-articles-sponsor{{#if count}}-{{ count }}{{/if}}{{#unless count}}-1{{/unless}}"
-      class="adunit--sponsor-logo js-sponsor-logo">
+      class="adunit--sponsor-logo">
     </div>
-  {{/if}}
+  </div>
+{{/if}}
 
-  {{#unless adpackage}}
+{{#unless adpackage}}
+  <div class="article__sponsor-ad js-article-sponsor-ad">
     <div class="adunit adunit--sponsor-logo display-none js-sponsor-logo"
       data-size-mapping="sponsor-logo"
       data-targeting='{ "position": "article-attribution" }'>
     </div>
-  {{/unless}}
-</div>
+  </div>
+{{/unless}}

--- a/src/components/article/article.hbs
+++ b/src/components/article/article.hbs
@@ -11,23 +11,26 @@
             {{ article.title }}
           </h1>
 
-          <div class="article-header__title is-xsmall is-padded-bottom js-header-title">
-            Tips &amp; articles
-
-            {{#if adpackage}}
+          {{#if adpackage}}
+            <div class="article-header__title is-xsmall is-padded-bottom">
               <div
                 id="ad-articles-sponsor-logo{{#if count}}-{{ count }}{{/if}}{{#unless count}}-1{{/unless}}"
-                class="adunit--sponsor-logo js-sponsor-logo">
+                class="adunit--sponsor-logo">
+                Tips &amp; articles
               </div>
-            {{/if}}
+            </div>
+          {{/if}}
 
-            {{#unless adpackage}}
+          {{#unless adpackage}}
+            <div class="article-header__title is-xsmall is-padded-bottom js-header-title">
+              Tips &amp; articles
+
               <div class="adunit adunit--sponsor-logo display-none js-sponsor-logo"
                 data-size-mapping="sponsor-logo"
                 data-targeting='{ "position": "header" }'>
               </div>
-            {{/unless}}
-          </div>
+            </div>
+          {{/unless}}
         </header>
       </div>
 

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -184,7 +184,8 @@ export default class ArticleComponent extends Component {
   _setInitialCallouts(callouts) {
     this.articleBody = new ArticleBodyComponent({
       el: this.$el.find(".js-article-body"),
-      poiData: callouts
+      poiData: callouts,
+      numberOfArticles: this.howManyArticlesHaveLoaded
     });
   }
 
@@ -413,7 +414,8 @@ export default class ArticleComponent extends Component {
   _updateNewArticle(model) {
     this.articleBody = new ArticleBodyComponent({
       el: this.$newArticle.find(".article-body"),
-      poiData: model.get("content").callouts
+      poiData: model.get("content").callouts,
+      numberOfArticles: (this.howManyArticlesHaveLoaded + 1)
     });
 
     this.socialShareComponent = new SocialShareComponent({

--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -344,8 +344,11 @@ export default class ArticleComponent extends Component {
     let nextArticle = new ArticleModel({ url: slug });
 
     return nextArticle.fetch().then(() => {
+      const getNextArticle = nextArticle.get();
+
       this.$newArticle = $(this.template({
-        article: nextArticle.get(),
+        article: getNextArticle,
+        adpackage: getNextArticle.features.indexOf("adpackage") > -1,
         count: (this.howManyArticlesHaveLoaded + 1)
       }))
       .appendTo(".page-container")

--- a/src/components/article/article_model.js
+++ b/src/components/article/article_model.js
@@ -2,6 +2,8 @@ import Model from "../../core/model";
 
 export default class ArticleModel extends Model {
   parse(response) {
-    return response.article;
+    return Object.assign({}, response.article, {
+      features: response.features
+    });
   }
 };

--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -16,6 +16,7 @@ export default class ArticleBodyComponent extends Component {
   initialize(options) {
     this.imageContainerSelector = ".stack__article__image-container";
     this.poiData = options.poiData;
+    this.howManyArticlesHaveLoaded = options.numberOfArticles;
 
     this.loadImages().then(() => {
       this.gallery = new ImageGallery({
@@ -140,7 +141,7 @@ export default class ArticleBodyComponent extends Component {
 
   _appendAd($paragraphs, $featuredImage) {
     const element = adpackage ? `<div
-      id="ad-articles-yieldmo"
+      id="ad-articles-yieldmo-${this.howManyArticlesHaveLoaded}"
       class="adunit--article"></div>` :
       `<div
         class="adunit adunit--article display-none"


### PR DESCRIPTION
1. Yieldmo ad needed a unique ID
2. Sponsored ads need to be loaded via GTM, so the hooks (`js-*` classnames) for the DFP template have been removed and wrapped in the feature flag.

https://github.com/lonelyplanet/articles/issues/13