### PR TITLE
Default features key in ArticleModel to empty array

### DIFF
--- a/src/components/article/article_model.js
+++ b/src/components/article/article_model.js
@@ -3,7 +3,7 @@ import Model from "../../core/model";
 export default class ArticleModel extends Model {
   parse(response) {
     return Object.assign({}, response.article, {
-      features: response.features
+      features: response.features || [],
     });
   }
 };


### PR DESCRIPTION
Fixes error:

```
TypeError: Cannot read property 'indexOf' of null at https://assets.lonelyplanet.com/javascripts/details.596d6ae414282329.js:3:11505 at <anonymous>
message
:
"Cannot read property 'indexOf' of null"
stack
:
"TypeError: Cannot read property 'indexOf' of null↵    at https://assets.lonelyplanet.com/javascripts/details.596d6ae414282329.js:3:11505↵    at <anonymous>"
```

the indexOf call is failing for `adpackage: a.features.indexOf("adpackage") > -1,`