### PR TITLE
Video component: Lower-third ads

### DIFF
--- a/lib/data/default.json
+++ b/lib/data/default.json
@@ -33,7 +33,7 @@
                 "slug": "//www.lonelyplanet.com/video/art-and-culture/v/cha/2"
               },
               {
-                "title": "Beaches",
+                "title": "Beaches, coasts and islands",
                 "slug": "//www.lonelyplanet.com/video/beaches/v/cha/3"
               },
               {

--- a/lib/data/header_normal.json
+++ b/lib/data/header_normal.json
@@ -34,7 +34,7 @@
                 "slug": "//www.lonelyplanet.com/video/art-and-culture/v/cha/2"
               },
               {
-                "title": "Beaches",
+                "title": "Beaches, coasts and islands",
                 "slug": "//www.lonelyplanet.com/video/beaches/v/cha/3"
               },
               {

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -2,24 +2,29 @@
 
 .video-js {
   margin: 0 auto;
-}
 
-.vjs-play-progress {
-  background-color: $lpblue;
-}
-
-.vjs-volume-level {
-  background-color: $lpblue;
-}
-
-.vjs-big-play-button {
-  &:hover,
-  &:active {
-    background-color: $lpblue;
+  .vjs-overlay-top-left {
+    top: 0;
+    left: 0;
   }
 
-  @media (max-width: $max-480) {
-    transform: scale(.7);
+  .vjs-overlay-bottom {
+    left: 0;
+    margin-left: 0;
+    max-width: 100% !important;
+    width: 100%;
+  }
+
+  .vjs-big-play-button {
+    @media (max-width: $max-480) {
+      transform: scale(.7);
+    }
+  }
+}
+
+.vjs-error {
+  .vjs-error-display {
+    display: none;
   }
 }
 
@@ -33,4 +38,23 @@
   margin-top: 8px;
   padding: 6px 24px;
   vertical-align: middle;
+}
+
+.video__lowerthird-overlay {
+  height: 0;
+  padding-bottom: 56.25%; /* 16:9 */
+  position: relative;
+
+  &>div {
+    height: 100% !important;
+    width: 100% !important;
+  }
+
+  iframe {
+    height: 100%;
+    left: 0;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
 }

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -4,14 +4,14 @@
   margin: 0 auto;
 
   .vjs-overlay-top-left {
-    top: 0;
     left: 0;
+    top: 0;
   }
 
   .vjs-overlay-bottom {
     left: 0;
     margin-left: 0;
-    max-width: 100% !important;
+    max-width: 100%;
     width: 100%;
   }
 
@@ -42,13 +42,8 @@
 
 .video__lowerthird-overlay {
   height: 0;
-  padding-bottom: 56.25%; /* 16:9 */
+  padding-bottom: 56.25%; // 16:9
   position: relative;
-
-  &>div {
-    height: 100% !important;
-    width: 100% !important;
-  }
 
   iframe {
     height: 100%;

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -46,71 +46,18 @@ class Brightcove extends VideoPlayer {
   }
 
   setup() {
-// <<<<<<< HEAD
-//     let self = this;
-//     videojs(this.videoEl).ready(function () {
-//       self.player = this;
-//       self.player.on("loadstart", self.onPlayerLoadStart.bind(self));
-//       self.player.on("playing", self.onPlayerPlaying.bind(self));
-//       self.player.on("ended", self.onPlayerEnded.bind(self));
-//       self.player.on("ads-ad-started", self.onAdStarted.bind(self));
-//       self.player.on("ads-ad-ended", self.onAdEnded.bind(self));
-//       self.trigger("ready");
-// =======
-    // let self = this;
     this.player = videojs(this.videoEl);
     this.player.ready(this.onPlayerReady.bind(this));
     this.player.on("loadstart", this.onPlayerLoadStart.bind(this));
-    // this.player.on("error", this.onPlayerError.bind(this));
     this.player.on("playing", this.onPlayerPlaying.bind(this));
     this.player.on("ended", this.onPlayerEnded.bind(this));
     this.player.on("ads-ad-started", this.onAdStarted.bind(this));
-    this.player.on("ads-ad-ended", this.onAdEnded.bind(self));
-
-    // videojs(this.videoEl).ready(function () {
-    //   self.player = this;
-    //   self.player.on("ended", () => { self.trigger("ended"); });
-    //   self.player
-    //   self.player.on("loadstart", this.onPlayerLoadStart.bind(this));
-    //   self.player.on("error", this.onPlayerError.bind(this));
-    //   self.player.on("playing", this.onPlayerPlaying.bind(this));
-    //   self.player.on("ended", this.onPlayerEnded.bind(this));
-    //   self.player.on("ads-ad-ended", this.onAdEnded.bind(this));
-    //   // self.setInitialDimensions();
-    //   self.trigger("ready");
-    // });
+    this.player.on("ads-ad-ended", this.onAdEnded.bind(this));
   }
 
   onPlayerReady() {
     this.trigger("ready");
   }
-
-  onPlayerLoadStart() {
-    this.renderSEOMarkup();
-
-    const tt = this.player.textTracks()[0];
-    if (tt) {
-      tt.oncuechange = this.onPlayerCueChange.bind(this);
-    }
-
-    this.configureOverlays();
-
-    // if (this.props.autoplay) {
-    //   this.player.play();
-    // }
-  }
-
-  // onPlayerError() {
-  //   this.loadVideo()
-  // }
-
-  onPlayerEnded() {
-    this.trigger("ended");
-  }
-
-  // onAdEnded() {
-
-  // }
 
   onPlayerCueChange() {
     const tt = this.player.textTracks()[0];
@@ -121,7 +68,7 @@ class Brightcove extends VideoPlayer {
 
     const cue = activeCue.originalCuePoint;
 
-    const overlayElementId = `ad-lowerthird-${this.cid}-${cue.id}`;
+    const overlayElementId = `ad-lowerthird-${this.playerId}-${cue.id}`;
     const element = document.getElementById(overlayElementId);
 
     if (!element) {
@@ -141,64 +88,6 @@ class Brightcove extends VideoPlayer {
     }
 
     window.lp.analytics.dfp.video.lowerThird(cueIndex + 1, overlayElementId);
-
-    // if (this.props.onCueChange) {
-    //   this.props.onCueChange(cue, cueIndex, overlayElementId);
-    // }
-  }
-
-  getCues() {
-    if (!this.player) {
-      return [];
-    }
-
-    const tt = this.player.textTracks()[0];
-    if (!tt) {
-      return [];
-    }
-
-    let index = 0;
-    const cues = [];
-    while (index < tt.cues.length) {
-      const cue = tt.cues[index];
-      if (cue.text === "CODE") {
-        cues.push(cue);
-      }
-      index += 1;
-    }
-
-    return cues;
-  }
-
-  configureOverlays() {
-    const overlays = this.getCues().map((c) => {
-      const cue = c.originalCuePoint;
-
-      const defaultEnd = cue.startTime + 15;
-      const end = defaultEnd < cue.endTime ? defaultEnd : cue.endTime;
-
-      return {
-        content: `<div id="ad-lowerthird-${this.cid}-${cue.id}" class="video__lowerthird-overlay" />`,
-        align: "bottom",
-        start: cue.startTime,
-        end,
-      };
-    });
-
-    overlays.push({
-      content: "<div class=\"video__ad-overlay\">Advertisement</div>",
-      align: "top-left",
-      start: "ads-ad-started",
-      end: "playing",
-    });
-
-    this.player.overlay({
-      content: "",
-      overlays,
-      showBackground: false,
-      attachToControlBar: true,
-      debug: false,
-    });
   }
 
   onPlayerLoadStart() {
@@ -236,44 +125,6 @@ class Brightcove extends VideoPlayer {
 
   onAdEnded() {
     this.disableAdOverlay();
-  }
-
-  onPlayerCueChange() {
-    const tt = this.player.textTracks()[0];
-    const activeCue = tt.activeCues[0];
-    if (!activeCue || activeCue.text !== "CODE") {
-      return;
-    }
-
-    const cue = activeCue.originalCuePoint;
-
-    const overlayElementId = "ad-lowerthird-" + this.playerId + "-" + cue.id;
-    const element = document.getElementById(overlayElementId);
-
-    if (!element) {
-      return;
-    }
-
-    let cueIndex = null;
-
-    this.getCues().forEach((c, i) => {
-      if (c.originalCuePoint.id === cue.id) {
-        cueIndex = i;
-      }
-    });
-
-    if (cueIndex === null) {
-      return;
-    }
-
-
-    console.log("HIT CUE", cue, cueIndex, overlayElementId);
-    try {
-      window.lp.analytics.dfp.video.lowerThird(cueIndex + 1, overlayElementId);
-    }
-    catch (e) {
-    }
-
   }
 
   enableAdOverlay() {

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -46,25 +46,26 @@ class Brightcove extends VideoPlayer {
   }
 
   setup() {
-<<<<<<< HEAD
-    let self = this;
-    videojs(this.videoEl).ready(function () {
-      self.player = this;
-      self.player.on("loadstart", self.onPlayerLoadStart.bind(self));
-      self.player.on("playing", self.onPlayerPlaying.bind(self));
-      self.player.on("ended", self.onPlayerEnded.bind(self));
-      self.player.on("ads-ad-started", self.onAdStarted.bind(self));
-      self.player.on("ads-ad-ended", self.onAdEnded.bind(self));
-      self.trigger("ready");
-=======
+// <<<<<<< HEAD
+//     let self = this;
+//     videojs(this.videoEl).ready(function () {
+//       self.player = this;
+//       self.player.on("loadstart", self.onPlayerLoadStart.bind(self));
+//       self.player.on("playing", self.onPlayerPlaying.bind(self));
+//       self.player.on("ended", self.onPlayerEnded.bind(self));
+//       self.player.on("ads-ad-started", self.onAdStarted.bind(self));
+//       self.player.on("ads-ad-ended", self.onAdEnded.bind(self));
+//       self.trigger("ready");
+// =======
     // let self = this;
     this.player = videojs(this.videoEl);
     this.player.ready(this.onPlayerReady.bind(this));
     this.player.on("loadstart", this.onPlayerLoadStart.bind(this));
     // this.player.on("error", this.onPlayerError.bind(this));
-    // this.player.on("playing", this.onPlayerPlaying.bind(this));
+    this.player.on("playing", this.onPlayerPlaying.bind(this));
     this.player.on("ended", this.onPlayerEnded.bind(this));
-    // this.player.on("ads-ad-ended", this.onAdEnded.bind(this));
+    this.player.on("ads-ad-started", this.onAdStarted.bind(this));
+    this.player.on("ads-ad-ended", this.onAdEnded.bind(self));
 
     // videojs(this.videoEl).ready(function () {
     //   self.player = this;
@@ -197,7 +198,6 @@ class Brightcove extends VideoPlayer {
       showBackground: false,
       attachToControlBar: true,
       debug: false,
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
     });
   }
 
@@ -281,25 +281,16 @@ class Brightcove extends VideoPlayer {
     adOverlay.css("display", "inline-block");
   }
 
-<<<<<<< HEAD
   disableAdOverlay() {
     const adOverlay = this.$el.find("#" + this.getAdOverlayId());
     adOverlay.css("display", "none");
   }
 
   fetchVideos() {
-=======
-  // isVideoLoaded(videoId) {
-  //   return this.player && this.player.mediainfo && this.player.mediainfo.id === videoId;
-  // }
-
-  loadVideo(videoId) {
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
     if (!this.player) {
       return Promise.resolve(false);
     }
 
-<<<<<<< HEAD
     let query = null;
     try {
       query = "ref:dest_" + window.lp.place.atlasId;
@@ -307,14 +298,10 @@ class Brightcove extends VideoPlayer {
     catch (e) {
       return Promise.resolve(false);
     }
-=======
-    // this.videoId = videoId;
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
 
     return new Promise((resolve) => {
       this.player.catalog.getPlaylist(query, (error, playlist) => {
         if (!error) {
-<<<<<<< HEAD
           this.videos = playlist.length ? playlist : [];
         }
         if (this.videos.length) {
@@ -329,16 +316,11 @@ class Brightcove extends VideoPlayer {
             }
             resolve(!error);
           });
-=======
-          this.player.catalog.load(video);
-
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
         }
       });
     });
   }
 
-<<<<<<< HEAD
   loadNextVideo() {
     if (!this.player || !this.videos.length) {
       return;
@@ -349,28 +331,6 @@ class Brightcove extends VideoPlayer {
 
     this.player.catalog.load(this.videos[this.currentVideoIndex]);
   }
-=======
-  /**
-   * Used to set the initial dimensions of the video player
-   * so that when video data begins to load, it sees that the player is fairly
-   * large and loads high-res video data.  We have an issue with Brightcove at the moment
-   * where it seems to load lower-res video if the player size is set to "mobile-like"
-   * dimensions, but we want to make sure we always have high-res video loaded (if available).
-   *
-   * This is run when the player is initially setup so consider resizing
-   * this.videoEl before making the player visible.
-   */
-  // setInitialDimensions() {
-  //   if (!this.player) {
-  //     return;
-  //   }
-
-  //   let width = 1280;
-  //   let height = width / this.defaultAspectRatio;
-
-  //   this.player.dimensions(width, height);
-  // }
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
 
   /**
    * Gets the ideal dimensions of the video, considering it's aspect ratio.
@@ -508,23 +468,15 @@ class Brightcove extends VideoPlayer {
     let seconds = Math.ceil(this.getVideoProperty("duration"));
     let duration = "PT" + seconds + "S";
 
-<<<<<<< HEAD
     let embedUrl = "https://players.brightcove.net/5104226627001/default_default/index.html?videoId=" + videoId;
 
-=======
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
     let data = {
       "@context": "http://schema.org",
       "@type": "VideoObject",
       "name": this.getVideoProperty("name") || defaultDescription,
       "description": this.getVideoProperty("description") || defaultDescription,
-<<<<<<< HEAD
-      "thumbnailURL": this.getVideoProperty("thumbnail"),
-      "embedURL": embedUrl,
-=======
       "thumbnailURL": this.getVideoProperty("poster"),
-      "embedURL": "https://players.brightcove.net/5104226627001/default_default/index.html?videoId=" + videoId,
->>>>>>> 9be0d2d3e2986e9433a883dd564a75d348e89be2
+      "embedURL": embedUrl,
       "duration": duration,
       "uploadDate": this.getVideoProperty("createdAt"),
     };

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -47,15 +47,16 @@ export default class VideoPosterButtonComponent extends Component {
   }
 
   render () {
-    let title = "";
+    this.renderImage();
+    this.renderText();
+  }
+
+  renderImage () {
     let image = null;
-    let description = "";
 
     try {
-        let mediainfo = this.player.player.mediainfo;
-        title = mediainfo.name || "";
+        const mediainfo = this.player.player.mediainfo;
         image = mediainfo.poster;
-        description = mediainfo.description || "";
     }
     catch (e) {
     }
@@ -75,11 +76,22 @@ export default class VideoPosterButtonComponent extends Component {
       this.$el.addClass("video-poster-button--visible");
     };
     imageEl.src = image;
+  }
+
+  renderText () {
+    let title = "";
+    let description = "";
+
+    try {
+        const mediainfo = this.player.player.mediainfo;
+        title = mediainfo.name || "";
+        description = mediainfo.description || "";
+    }
+    catch (e) {
+    }
 
     this.$el.find(".video-poster-button__title").text(title);
-    this.$el.find(".video-poster-button__description").text(description);
-
-    return this;
+    this.$el.find(".video-poster-button__description").html(description);
   }
 
   onClick (e) {
@@ -94,14 +106,22 @@ export default class VideoPosterButtonComponent extends Component {
   playerReady (player) {
     this.player = player;
     this.listenTo(this.player, "ended", this.onPlayerEnded.bind(this));
+    this.listenTo(this.player, "loadstart", this.onPlayerLoadStart.bind(this));
     this.player.fetchVideos().then(this.fetchDone.bind(this));
   }
 
   /**
-   * Callback from the player "ended" event / when a video or playlist finishes playing.
+   * Callback from the player "ended" event / when the playlist finishes playing.
    */
   onPlayerEnded () {
     this.hideVideo();
+  }
+
+  /**
+   * Callback from the player "loadstart" event / when a video is loaded and is ready to play.
+   */
+  onPlayerLoadStart () {
+    this.renderText();
   }
 
   /**


### PR DESCRIPTION
#### This is almost entirely just ported from backpack's `VideoEmbed` component ####

- Updated site header (beaches -> beaches, coasts and islands)
- Removed `lpblue` color styling in video component (controlled via brightcove instead)
- Fixed `Advertisement` overlay not disappearing once video starts
- Added lower-third ad support
- description text under `video_poster_button` component now updates as each video plays if a playlist is being played