### PR TITLE
Add toast to global header component

### DIFF
--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -1,4 +1,5 @@
 import { Component } from "../../core/bane";
+import CookieUtil from "../../core/cookie_util";
 import SearchComponent from "../search";
 import NavigationComponent from "../navigation";
 import NavigationState from "../navigation/navigation_state";
@@ -36,6 +37,8 @@ class Header extends Component {
 
     this.appendMenuIcon();
     this.buildGlobalComponents(options);
+
+    this.cookieUtil = new CookieUtil();
   }
 
   buildGlobalComponents(options = {}) {
@@ -64,25 +67,24 @@ class Header extends Component {
       toast.id = "lp-global-toast";
       document.body.appendChild(toast);
 
-      const toastTitle = sessionStorage.getItem("lp-toastTitle");
-      const toastMessage = sessionStorage.getItem("lp-toastMessage");
-      const toastType = sessionStorage.getItem("lp-toastType");
+      const toastData = this.cookieUtil.getCookie("lpToast");
       const toastDuration = 3000;
 
-      if (toastMessage && toastType) {
+      if (toastData) {
+        const data = JSON.parse(toastData);
+
         render({
           component: "GlobalToast",
           el: toast,
           props: {
-            title: toastTitle,
-            message: toastMessage,
-            type: toastType,
+            title: data.title,
+            message: data.message,
+            type: data.type,
             duration: toastDuration,
           },
         });
 
-        sessionStorage.removeItem("lp-toastMessage");
-        sessionStorage.removeItem("lp-toastType");
+        this.cookieUtil.removeCookie("lpToast");
 
         setTimeout(() => {
           document.body.removeChild(toast);

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -69,6 +69,7 @@ class Header extends Component {
 
       const toastData = this.cookieUtil.getCookie("lpToast");
       const toastDuration = 3000;
+      const animationDuration = 200;
 
       if (toastData) {
         const data = JSON.parse(toastData);
@@ -81,6 +82,7 @@ class Header extends Component {
             message: data.message,
             type: data.type,
             duration: toastDuration,
+            animationDuration,
           },
         });
 

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -83,14 +83,15 @@ class Header extends Component {
             type: data.type,
             duration: toastDuration,
             animationDuration,
+            onClose: () => {
+              this.cookieUtil.removeCookie("lpToast");
+
+              setTimeout(() => {
+                document.body.removeChild(toast);
+              }, animationDuration);
+            },
           },
         });
-
-        this.cookieUtil.removeCookie("lpToast");
-
-        setTimeout(() => {
-          document.body.removeChild(toast);
-        }, toastDuration + 200);
       }
     });
   }

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -60,14 +60,34 @@ class Header extends Component {
         props: options,
       });
 
-      // TODO: Add logic for toast
-      /*
-      const toastMessage = localStorage.getItem("toast");
-      if (toastMessage) {
-        console.log(toastMessage);
-        localStorage.removeItem("toast");
+      const toast = document.createElement("div");
+      toast.id = "lp-global-toast";
+      document.body.appendChild(toast);
+
+      const toastTitle = sessionStorage.getItem("lp-toastTitle");
+      const toastMessage = sessionStorage.getItem("lp-toastMessage");
+      const toastType = sessionStorage.getItem("lp-toastType");
+      const toastDuration = 3000;
+
+      if (toastMessage && toastType) {
+        render({
+          component: "GlobalToast",
+          el: toast,
+          props: {
+            title: toastTitle,
+            message: toastMessage,
+            type: toastType,
+            duration: toastDuration,
+          },
+        });
+
+        sessionStorage.removeItem("lp-toastMessage");
+        sessionStorage.removeItem("lp-toastType");
+
+        setTimeout(() => {
+          document.body.removeChild(toast);
+        }, toastDuration + 200);
       }
-      */
     });
   }
 


### PR DESCRIPTION
Reads values from a browser cookie to display the toast.

The cookie `lpToast` should be set with JSON data (this example uses Rizzo next's `CookieUtil`):

```
this.cookieUtil.setCookie("lpToast", JSON.stringify({
  "message": "Message",
  "title": "Title",
  "type": "success"
}), 1);
```

* `message`: required
* `type`: required; one of “error”, “info”, “success” or “warning”
* `title`: optional

Duration is hard-coded as 3 seconds, but that value could be set in the cookie as well if certain toasts need more or less time on screen.