### PR TITLE
Updated ImageGallery to support Brightcove videos

### DIFF
--- a/src/components/image_gallery/image_gallery.js
+++ b/src/components/image_gallery/image_gallery.js
@@ -97,7 +97,6 @@ export default class ImageGalleryComponent extends Component {
    */
   onGalleryClose() {
     this._videoStop();
-    // this._youtubeStop();
   }
 
   /**
@@ -105,35 +104,10 @@ export default class ImageGalleryComponent extends Component {
    */
   onGalleryChange() {
     this._videoPlay(this._gallery.currItem);
-    // this._youtubePlay(this._gallery.currItem);
-    // this._brightcovePlay(this._gallery.currItem);
   }
 
-  /**
-   * Plays youtube movie if given proper movie ID
-   */
-  // _youtubePlay(galleryItem) {
-  //   if (galleryItem.youtubeID) {
-  //     this._player = document.getElementById(galleryItem.youtubeID);
-  //     this._player.innerHTML = "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/" + galleryItem.youtubeID + "?autoplay=1' frameborder='0' allowfullscreen></iframe>";
-  //   } else {
-  //     this._youtubeStop();
-  //   }
-  // }
-  //
-  // /**
-  //  * Plays brightcove movie if given proper movie ID
-  //  */
-  // _brightcovePlay(galleryItem) {
-  //   if (galleryItem.brightcoveID) {
-  //     this._player = document.getElementById(galleryItem.brightcoveID);
-  //     Video.addPlayer(this._player, "brightcove").then(this.playerReady.bind(this));
-  //   } else {
-  //     this._brightcoveStop();
-  //   }
-  // }
-
   _videoPlay(galleryItem) {
+    this._videoStop();
     if (galleryItem.videoID) {
       Video.addPlayer(
         galleryItem.videoID,
@@ -141,37 +115,11 @@ export default class ImageGalleryComponent extends Component {
           videoId: galleryItem.videoID,
           autoplay: this.autoplayVideos }).then(this.playerReady.bind(this));
     }
-    else {
-      this._videoStop();
-    }
   }
 
   playerReady (player) {
     this._player = player;
-    // this.bcPlayer = player;
-    // this.listenTo(this.player, "ended", this.onPlayerEnded.bind(this));
-    // this.player.fetchVideos().then(this.fetchDone.bind(this));
   }
-
-  /**
-   * Stops youtube movie and destroys the player
-   */
-  // _youtubeStop() {
-  //   if (this._player) {
-  //     this._player.innerHTML = "";
-  //     this._player = null;
-  //   }
-  // }
-  //
-  // _brightcoveStop() {
-  //   if (this.bcPlayer) {
-  //     // this.bcPlayer.dispose();
-  //   }
-  //   if (this._player) {
-  //     this._player.innerHTML = "";
-  //     this._player = null;
-  //   }
-  // }
 
   _videoStop() {
     if (this._player) {
@@ -194,7 +142,7 @@ export default class ImageGalleryComponent extends Component {
    * Gets brightcove movie id from given brightcove movie url
    */
   _brightcoveID(url) {
-    let regExp = /^.*\.brightcove\..*(\/videos\/|\?videoId=)([0-9]+)$/,
+    let regExp = /^.*\.brightcove\..*(\/videos\/|\?videoId=)([0-9]+).*/,
       match = url.match(regExp);
 
     return match ? match[2] : null;

--- a/src/components/image_gallery/image_gallery.js
+++ b/src/components/image_gallery/image_gallery.js
@@ -137,8 +137,8 @@ export default class ImageGalleryComponent extends Component {
     if (galleryItem.videoID) {
       Video.addPlayer(
         galleryItem.videoID,
-        galleryItem.videoType,
-        { videoId: galleryItem.videoID,
+        { type: galleryItem.videoType,
+          videoId: galleryItem.videoID,
           autoplay: this.autoplayVideos }).then(this.playerReady.bind(this));
     }
     else {

--- a/src/components/image_gallery/image_gallery.js
+++ b/src/components/image_gallery/image_gallery.js
@@ -2,6 +2,7 @@ import { Component } from "../../core/bane";
 import $ from "jquery";
 import PhotoSwipe from "photoswipe";
 import PhotoSwipeUI_Default from "photoswipe/dist/photoswipe-ui-default";
+import Video from "../video";
 
 // Keep track of instance IDs
 let instanceId = 0;
@@ -23,9 +24,11 @@ export default class ImageGalleryComponent extends Component {
   }
 
   initialize({
-    galleryImageSelector = ".stack__article__image-container"
+    galleryImageSelector = ".stack__article__image-container",
+    autoplayVideos = true
   } = {}) {
     this.template = require("./image_gallery.hbs");
+    this.autoplayVideos = autoplayVideos;
 
     this.$images = this.$el.find(galleryImageSelector);
 
@@ -53,14 +56,17 @@ export default class ImageGalleryComponent extends Component {
           image = $linkEl.find("img").attr("src"),
           link = $linkEl.attr("href"),
           largeImage = link.match(/\.(jpg|png|gif)/) ? link : image,
-          youtubeID = this._youtubeID(link);
+          youtubeID = this._youtubeID(link),
+          brightcoveID = this._brightcoveID(link);
 
       let item = {
         src: largeImage,
         msrc: image,
         el: $linkEl.find("img")[0],
         w: parseInt(size[0], 10),
-        h: parseInt(size[1], 10)
+        h: parseInt(size[1], 10),
+        videoID: youtubeID || brightcoveID,
+        videoType: youtubeID ? "youtube" : brightcoveID ? "brightcove" : null,
       };
 
       let $caption;
@@ -72,9 +78,8 @@ export default class ImageGalleryComponent extends Component {
         item.title = $caption.html();
       }
 
-      if (youtubeID) {
-        item.youtubeID = youtubeID;
-        item.html = "<div class='pswp__player' id='" + youtubeID + "'></div>";
+      if (item.videoID) {
+        item.html = "<div class='pswp__player' id='" + item.videoID + "'></div>";
         item.title = null;
         item.src = null;
         item.msrc = null;
@@ -91,34 +96,86 @@ export default class ImageGalleryComponent extends Component {
    * Callback from photoswipe gallery close
    */
   onGalleryClose() {
-    this._youtubeStop();
+    this._videoStop();
+    // this._youtubeStop();
   }
 
   /**
    * Callback from photoswipe item change
    */
   onGalleryChange() {
-    this._youtubePlay(this._gallery.currItem);
+    this._videoPlay(this._gallery.currItem);
+    // this._youtubePlay(this._gallery.currItem);
+    // this._brightcovePlay(this._gallery.currItem);
   }
 
   /**
    * Plays youtube movie if given proper movie ID
    */
-  _youtubePlay(galleryItem) {
-    if (galleryItem.youtubeID) {
-      this._player = document.getElementById(galleryItem.youtubeID);
-      this._player.innerHTML = "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/" + galleryItem.youtubeID + "?autoplay=1' frameborder='0' allowfullscreen></iframe>";
-    } else {
-      this._youtubeStop();
+  // _youtubePlay(galleryItem) {
+  //   if (galleryItem.youtubeID) {
+  //     this._player = document.getElementById(galleryItem.youtubeID);
+  //     this._player.innerHTML = "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/" + galleryItem.youtubeID + "?autoplay=1' frameborder='0' allowfullscreen></iframe>";
+  //   } else {
+  //     this._youtubeStop();
+  //   }
+  // }
+  //
+  // /**
+  //  * Plays brightcove movie if given proper movie ID
+  //  */
+  // _brightcovePlay(galleryItem) {
+  //   if (galleryItem.brightcoveID) {
+  //     this._player = document.getElementById(galleryItem.brightcoveID);
+  //     Video.addPlayer(this._player, "brightcove").then(this.playerReady.bind(this));
+  //   } else {
+  //     this._brightcoveStop();
+  //   }
+  // }
+
+  _videoPlay(galleryItem) {
+    if (galleryItem.videoID) {
+      Video.addPlayer(
+        galleryItem.videoID,
+        galleryItem.videoType,
+        { videoId: galleryItem.videoID,
+          autoplay: this.autoplayVideos }).then(this.playerReady.bind(this));
     }
+    else {
+      this._videoStop();
+    }
+  }
+
+  playerReady (player) {
+    this._player = player;
+    // this.bcPlayer = player;
+    // this.listenTo(this.player, "ended", this.onPlayerEnded.bind(this));
+    // this.player.fetchVideos().then(this.fetchDone.bind(this));
   }
 
   /**
    * Stops youtube movie and destroys the player
    */
-  _youtubeStop() {
+  // _youtubeStop() {
+  //   if (this._player) {
+  //     this._player.innerHTML = "";
+  //     this._player = null;
+  //   }
+  // }
+  //
+  // _brightcoveStop() {
+  //   if (this.bcPlayer) {
+  //     // this.bcPlayer.dispose();
+  //   }
+  //   if (this._player) {
+  //     this._player.innerHTML = "";
+  //     this._player = null;
+  //   }
+  // }
+
+  _videoStop() {
     if (this._player) {
-      this._player.innerHTML = "";
+      this._player.dispose();
       this._player = null;
     }
   }
@@ -128,9 +185,19 @@ export default class ImageGalleryComponent extends Component {
    */
   _youtubeID(url) {
     let regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/,
-        match = url.match(regExp);
+      match = url.match(regExp);
 
     return match && match[2].length == 11 ? match[2] : null;
+  }
+
+  /**
+   * Gets brightcove movie id from given brightcove movie url
+   */
+  _brightcoveID(url) {
+    let regExp = /^.*\.brightcove\..*(\/videos\/|\?videoId=)([0-9]+)$/,
+      match = url.match(regExp)
+
+    return match ? match[2] : null;
   }
 
   /**

--- a/src/components/image_gallery/image_gallery.js
+++ b/src/components/image_gallery/image_gallery.js
@@ -195,7 +195,7 @@ export default class ImageGalleryComponent extends Component {
    */
   _brightcoveID(url) {
     let regExp = /^.*\.brightcove\..*(\/videos\/|\?videoId=)([0-9]+)$/,
-      match = url.match(regExp)
+      match = url.match(regExp);
 
     return match ? match[2] : null;
   }

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -1,7 +1,9 @@
 @import "../../../sass/webpack_deps";
 
 .video-js {
+  height: 100%;
   margin: 0 auto;
+  width: 100%;
 }
 
 .vjs-play-progress {

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -4,10 +4,9 @@ import VideoPlayer from "./video_player";
 
 class Brightcove extends VideoPlayer {
 
-  initialize(options) {
-    super.initialize(options);
+  initialize(playerId, options={}) {
+    super.initialize(playerId, options);
 
-    this.autoplay = false;
     this.videos = [];
     this.currentVideoIndex = null;
 
@@ -46,6 +45,10 @@ class Brightcove extends VideoPlayer {
   }
 
   setup() {
+    if (!this.videoEl) {
+
+    }
+
     let self = this;
     videojs(this.videoEl).ready(function () {
       self.player = this;
@@ -53,6 +56,13 @@ class Brightcove extends VideoPlayer {
       self.player.on("ended", self.onPlayerEnded.bind(self));
       self.trigger("ready");
     });
+  }
+
+  dispose() {
+    if (this.player) {
+      this.player.dispose();
+      this.player = null;
+    }
   }
 
   onPlayerLoadStart() {

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -4,8 +4,8 @@ import VideoPlayer from "./video_player";
 
 class Brightcove extends VideoPlayer {
 
-  initialize(playerId, options={}) {
-    super.initialize(playerId, options);
+  initialize(options) {
+    super.initialize(options);
 
     this.videos = [];
     this.currentVideoIndex = null;

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -46,23 +46,71 @@ class Brightcove extends VideoPlayer {
 
   setup() {
     if (!this.videoEl) {
+      // Insert brightcove player html
+      let html = "<video ";
+      if (this.videoId) {
+        html += "data-video-id='" + this.videoId + "' ";
+      }
+      html += "data-account='5104226627001' ";
+      html += "data-player='default' ";
+      html += "data-embed='default' ";
+      html += "data-application-id ";
+      html += "class='video-js' ";
+      html += "></video>";
+      this.el.innerHTML = html;
 
+      // Insert script to initialize brightcove player
+      const scriptId = this.getPlayerScriptId();
+      const scriptSrc = "https://players.brightcove.net/5104226627001/default_default/index.min.js";
+      const script = document.createElement("script");
+
+      script.id = scriptId;
+      script.src = scriptSrc;
+      script.onload = this.onLoadSetupScript.bind(this);
+
+      document.body.appendChild(script);
     }
+    else {
+      let self = this;
+      videojs(this.videoEl).ready(function () {
+        self.player = this;
 
-    let self = this;
-    videojs(this.videoEl).ready(function () {
-      self.player = this;
-      self.player.on("loadstart", self.onPlayerLoadStart.bind(self));
-      self.player.on("ended", self.onPlayerEnded.bind(self));
-      self.trigger("ready");
-    });
+        // We don't show the controls until the player is instantiated
+        // or else the controls show briefly without the brightcove theme applied.
+        self.player.controls(true);
+
+        self.player.on("loadstart", self.onPlayerLoadStart.bind(self));
+        self.player.on("ended", self.onPlayerEnded.bind(self));
+
+        self.trigger("ready");
+      });
+    }
   }
 
   dispose() {
+    const scriptId = this.getPlayerScriptId();
+    const script = document.getElementById(scriptId);
+
+    if (script) {
+      script.remove();
+    }
+
     if (this.player) {
       this.player.dispose();
       this.player = null;
     }
+  }
+
+  isReady() {
+    return this.player && this.player.isReady_;
+  }
+
+  getPlayerScriptId() {
+    return "video__initialize-" + this.playerId;
+  }
+
+  onLoadSetupScript() {
+    this.setup();
   }
 
   onPlayerLoadStart() {

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -14,7 +14,11 @@ class Video {
     autoplay = false} = {}) {
 
     if (typeof element === "string") {
-      element = $(element)[0];
+      element = document.getElementById(element);
+    }
+
+    if (!element) {
+      return;
     }
 
     this.players = this.players || new Map();
@@ -32,6 +36,10 @@ class Video {
     // Take the return value and use .then() on it to ensure the
     // player is ready before using it.
     return new Promise((resolve) => {
+      if (player.isReady()) {
+        resolve(player);
+        return;
+      }
       player.on("ready", () => {
         resolve(player);
       });

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -8,7 +8,11 @@ players.set("brightcove", Brightcove);
 players.set("youtube", Youtube);
 
 class Video {
-  static addPlayer(element, type="brightcove", options={}) {
+  static addPlayer(element, {
+    type = "brightcove",
+    videoId = null,
+    autoplay = false} = {}) {
+
     if (typeof element === "string") {
       element = $(element)[0];
     }
@@ -19,8 +23,8 @@ class Video {
         player = new PlayerConstructor({
           el: element,
           playerId: this.players.size + 1,
-          videoId: options.videoId || null,
-          autoplay: options.autplay || false,
+          videoId,
+          autoplay,
         });
 
     this.players.set(element, player);

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -1,12 +1,14 @@
 import Brightcove from "./brightcove";
+import Youtube from "./youtube";
 
 require("./_video.scss");
 
 let players = new Map();
 players.set("brightcove", Brightcove);
+players.set("youtube", Youtube);
 
 class Video {
-  static addPlayer(element, type="brightcove") {
+  static addPlayer(element, type="brightcove", options={}) {
     if (typeof element === "string") {
       element = $(element)[0];
     }
@@ -16,12 +18,14 @@ class Video {
     let PlayerConstructor = players.get(type),
         player = new PlayerConstructor({
           el: element,
-          playerId: this.players.size + 1
+          playerId: this.players.size + 1,
+          videoId: options.videoId || null,
+          autoplay: options.autplay || false,
         });
 
     this.players.set(element, player);
 
-    // Take the return value and use .then() on it to ensure the 
+    // Take the return value and use .then() on it to ensure the
     // player is ready before using it.
     return new Promise((resolve) => {
       player.on("ready", () => {

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -11,6 +11,10 @@ class VideoPlayer extends Component {
     this.setup();
   }
 
+  isReady() {
+    return true;
+  }
+
   /**
    * Run any setup to load the player (ex. videojs player).
    * Make sure this.trigger("ready") is called within this function.

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -2,8 +2,10 @@ import { Component } from "../../core/bane";
 
 class VideoPlayer extends Component {
 
-  initialize({ playerId }) {
+  initialize(playerId, options={}) {
     this.playerId = playerId;
+    this.videoId = options.videoId || null;
+    this.autoplay = options.autoplay || false;
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
     this.setup();
@@ -18,6 +20,12 @@ class VideoPlayer extends Component {
   }
 
   /**
+   * Override to actually kill the underlying player
+   */
+  dispose() {
+  }
+
+  /**
    * Override to actually play the underlying player
    */
   play() {
@@ -28,6 +36,7 @@ class VideoPlayer extends Component {
    */
   pause() {
   }
+
 
 }
 

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -2,10 +2,10 @@ import { Component } from "../../core/bane";
 
 class VideoPlayer extends Component {
 
-  initialize(playerId, options={}) {
+  initialize({playerId, videoId=null, autoplay=false}) {
     this.playerId = playerId;
-    this.videoId = options.videoId || null;
-    this.autoplay = options.autoplay || false;
+    this.videoId = videoId;
+    this.autoplay = autoplay;
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
     this.setup();

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -14,7 +14,6 @@ class Youtube extends VideoPlayer {
 
       this.$el.html(html);
     }
-
     this.trigger("ready");
   }
 

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -3,19 +3,18 @@ import VideoPlayer from "./video_player";
 class Youtube extends VideoPlayer {
 
   setup() {
-    if (!this.videoId) {
-      return;
+    if (this.videoId) {
+      let html = "";
+      html += "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/";
+      html += this.videoId;
+      if (this.autoplay) {
+        html += "?autoplay=1";
+      }
+      html += "' frameborder='0' allowfullscreen></iframe>";
+
+      this.$el.html(html);
     }
 
-    let html = "";
-    html += "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/";
-    html += this.videoId;
-    if (this.autoplay) {
-      html += "?autoplay=1";
-    }
-    html += "' frameborder='0' allowfullscreen></iframe>";
-
-    this.$el.html(html);
     this.trigger("ready");
   }
 
@@ -23,3 +22,5 @@ class Youtube extends VideoPlayer {
     this.$el.html('');
   }
 }
+
+export default Youtube;

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -19,7 +19,7 @@ class Youtube extends VideoPlayer {
   }
 
   dispose() {
-    this.$el.html('');
+    this.$el.html("");
   }
 }
 

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -1,0 +1,25 @@
+import VideoPlayer from "./video_player";
+
+class Youtube extends VideoPlayer {
+
+  setup() {
+    if (!this.videoId) {
+      return;
+    }
+
+    let html = "";
+    html += "<iframe width='100%' height='100%' src='https://www.youtube.com/embed/";
+    html += this.videoId;
+    if (this.autoplay) {
+      html += "?autoplay=1";
+    }
+    html += "' frameborder='0' allowfullscreen></iframe>";
+
+    this.$el.html(html);
+    this.trigger("ready");
+  }
+
+  dispose() {
+    this.$el.html('');
+  }
+}

--- a/src/components/video_overlay/video_overlay.hbs
+++ b/src/components/video_overlay/video_overlay.hbs
@@ -4,14 +4,6 @@
   </div>
   <div class="video-overlay__video">
     <div class="video-overlay__video__container">
-      <video data-account="5104226627001" 
-        data-player="default" 
-        data-embed="default" 
-        data-application-id 
-        class="video-js" 
-        controls >
-      </video>
-      <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
     </div>
   </div>
 </div>

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -12,7 +12,7 @@ export default class VideoOverlay extends Overlay {
 
     this.resizeBound = false;
 
-    Video.addPlayer(this.$el.find('.video-overlay__video__container')[0]).then(this.playerReady.bind(this));
+    Video.addPlayer(this.$el.find(".video-overlay__video__container")[0]).then(this.playerReady.bind(this));
   }
 
   show () {

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -12,7 +12,7 @@ export default class VideoOverlay extends Overlay {
 
     this.resizeBound = false;
 
-    Video.addPlayer(this.el, "brightcove").then(this.playerReady.bind(this));
+    Video.addPlayer(this.$el.find('.video-overlay__video__container')[0]).then(this.playerReady.bind(this));
   }
 
   show () {

--- a/src/components/video_poster_button/video_poster_button.hbs
+++ b/src/components/video_poster_button/video_poster_button.hbs
@@ -14,14 +14,6 @@
                 </div>
             </a>
             <div class="video-poster-button__video">
-                <video data-account="5104226627001" 
-                    data-player="default" 
-                    data-embed="default" 
-                    data-application-id 
-                    class="video-js" 
-                    controls >
-                </video>
-                <script src="//players.brightcove.net/5104226627001/default_default/index.min.js"></script>
             </div>
         </div>
         <div class="video-poster-button__description">

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -12,7 +12,7 @@ export default class VideoPosterButtonComponent extends Component {
         "click .video-poster-button__inner": "onClick"
     };
 
-    Video.addPlayer(this.$el.find('.video-poster-button__video')[0]).then(this.playerReady.bind(this));
+    Video.addPlayer(this.$el.find(".video-poster-button__video")[0]).then(this.playerReady.bind(this));
   }
 
   showVideo () {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -6,14 +6,13 @@ import Video from "../video";
 */
 export default class VideoPosterButtonComponent extends Component {
   initialize () {
-
     this.playerVisible = false;
 
     this.events = {
         "click .video-poster-button__inner": "onClick"
     };
 
-    Video.addPlayer(this.el, "brightcove").then(this.playerReady.bind(this));
+    Video.addPlayer(this.$el.find('.video-poster-button__video')[0]).then(this.playerReady.bind(this));
   }
 
   showVideo () {
@@ -66,12 +65,6 @@ export default class VideoPosterButtonComponent extends Component {
 
     let imageEl = this.$el.find(".video-poster-button__poster")[0];
     imageEl.onload = () => {
-
-      // Reset the width and height of the player to be the same
-      // dimensions as the poster image so that we have a nice
-      // smooth transition (and to undo Brightcove.setInitialDimensions())
-      $(this.player.videoEl).css({ width: "100%", height: "100%" });
-
       this.$el.addClass("video-poster-button--visible");
     };
     imageEl.src = image;


### PR DESCRIPTION
- Youtube videos are still supported
- Youtube and Brightcove videos are inserted via the `Video` component interface - so all methods in `ImageGallery` are now generic
- `Brightcove` player has been updated to insert it's own embed code instead of relying on it to already exist on the page (so removed the embed code from all templates as well)