### PR TITLE
fix: add modal trigger to mobile nav

### DIFF
--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -193,11 +193,8 @@ class NavigationComponent extends Component {
 
     if (!user.id) {
       if (this.showNewLoginLink()) {
-        $(".navigation__link[href*='sign_in']", $(".lp-global-header__navigation"))
-          .attr("href", "#login");
-
-        $(".mobile-navigation__link[href*='sign_in']", $(".mobile-navigation"))
-          .attr("href", "#login");
+        this.$el.find(".navigation__link[href*='sign_in']").attr("href", "#login");
+        this.$mobileNavigation.find(".mobile-navigation__link[href*='sign_in']").attr("href", "#login");
       }
       return;
     }

--- a/src/components/navigation/sign_out_link.hbs
+++ b/src/components/navigation/sign_out_link.hbs
@@ -1,3 +1,3 @@
-<a class="mobile-navigation__link" href="//auth.lonelyplanet.com/users/sign_out">
+<a class="mobile-navigation__link" href="{{user.signOutLink}}">
   Sign Out
 </a>


### PR DESCRIPTION
adding the `#login` to the href needed to happen after the mobile menu is added to the dom