### PR TITLE
feat: remove auth modal and global toast from

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lint"
   ],
   "dependencies": {
-    "@lonelyplanet/dotcom-core": "^1.3.7",
     "airbrake-js": "^0.9.3",
     "async": "^2.0.0-rc.4",
     "babel-core": "^6.5.2",

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -1,5 +1,4 @@
 import { Component } from "../../core/bane";
-import CookieUtil from "../../core/cookie_util";
 import SearchComponent from "../search";
 import NavigationComponent from "../navigation";
 import NavigationState from "../navigation/navigation_state";
@@ -13,8 +12,7 @@ import debounce from "lodash/debounce";
  */
 class Header extends Component {
 
-  initialize(options) {
-    this.lazyLoadGlobalComponents = this.lazyLoadGlobalComponents.bind(this);
+  initialize() {
     this.state = NavigationState.getState();
     this.search = new SearchComponent();
     this.navigation = new NavigationComponent({
@@ -36,64 +34,13 @@ class Header extends Component {
     this.$mobileNotificationBadge = require("./mobile_notification_badge.hbs");
 
     this.appendMenuIcon();
-    this.buildGlobalComponents(options);
-
-    this.cookieUtil = new CookieUtil();
+    this.buildGlobalComponents();
   }
 
-  buildGlobalComponents(options = {}) {
-    this.lazyLoadGlobalComponents(options);
-
+  buildGlobalComponents() {
     $(document).on("touchstart", "a[href*='login']", () => {
       this.navigation._clickNav();
     });
-  }
-
-  lazyLoadGlobalComponents(options) {
-    require.ensure([], (require) => {
-      const render = require("@lonelyplanet/dotcom-core/dist/classes/runtime").default;
-
-      const modal = document.createElement("div");
-      modal.id = "lp-global-modal-login";
-      document.body.appendChild(modal);
-
-      render({
-        component: "GlobalLogin",
-        el: modal,
-        props: options,
-      });
-
-      const toast = document.createElement("div");
-      toast.id = "lp-global-toast";
-      document.body.appendChild(toast);
-
-      const toastData = this.cookieUtil.getCookie("lpToast");
-      const toastDuration = 3000;
-      const animationDuration = 200;
-
-      if (toastData) {
-        const data = JSON.parse(toastData);
-
-        render({
-          component: "GlobalToast",
-          el: toast,
-          props: {
-            title: data.title,
-            message: data.message,
-            type: data.type,
-            duration: toastDuration,
-            animationDuration,
-            onClose: () => {
-              this.cookieUtil.removeCookie("lpToast");
-
-              setTimeout(() => {
-                document.body.removeChild(toast);
-              }, animationDuration);
-            },
-          },
-        });
-      }
-    }, "rizzo_next_global_components");
   }
 
   /**

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -193,8 +193,10 @@ class NavigationComponent extends Component {
 
     if (!user.id) {
       if (this.showNewLoginLink()) {
-        this.$el.find(".navigation__link[href*='sign_in']").attr("href", "#login");
-        this.$mobileNavigation.find(".mobile-navigation__link[href*='sign_in']").attr("href", "#login");
+        // lp.require is a way to detect if this is a legacy app or not (/¯◡ ‿ ◡)/¯ ~ ┻━┻
+        const loginLink = window.lp.require ? "https://connect.lonelyplanet.com" : "#login";
+        this.$el.find(".navigation__link[href*='sign_in']").attr("href", loginLink);
+        this.$mobileNavigation.find(".mobile-navigation__link[href*='sign_in']").attr("href", loginLink);
       }
       return;
     }


### PR DESCRIPTION
Removing global auth and toast from rizzo-next in favor of pulling these components into each app directly from `dotcom-core`. 

Loading through rizzo-next was causing an extra large bundle to be required