### PR TITLE
Update package.json scripts for creating releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "scsslint": "scss-lint . --config .scss-lint.yml",
     "test": "karma start --single-run",
     "preversion": "npm run build",
-    "version": "standard-version --commit-all",
-    "version:patch": "standard-version -- --release-as patch",
-    "version:minor": "standard-version -- --release-as minor",
-    "version:major": "standard-version --release-as major"
+    "release": "standard-version",
+    "version": "npm run release --commit-all",
+    "version:patch": "npm run release -- --release-as patch",
+    "version:minor": "npm run release -- --release-as minor",
+    "version:major": "npm run release -- --release-as major"
   },
   "version": "0.20.0",
   "pre-commit": [


### PR DESCRIPTION
I think I encountered a bug when I tried to run `npm run version:minor` because a patch version was created instead. This should make sure the `--commit-all` flag is applied to all `version` scripts. Not sure if that is the issue, but this is the code we have in backpack-ui and seems to be working as expected.