### PR TITLE
fix history import

### DIFF
--- a/spec/unit/components/map.spec.js
+++ b/spec/unit/components/map.spec.js
@@ -9,12 +9,10 @@ let MapComponent = Injector({
     createElement: function() {}
   },
   "./views/main.jsx": function() {},
-  "history": {
-    createHistory: function() {
-      return {
-        push: pushState
-      };
-    }
+  "history/createBrowserHistory": function() {
+    return {
+      push: pushState
+    };
   },
   "./map_api": {
     fetch: () => {

--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -4,7 +4,7 @@ import { render } from "react-dom";
 import MainView from "./views/main.jsx";
 import MapActions from "./actions";
 import Arkham from "../../core/arkham";
-import { createHistory } from "history";
+import createHistory from "history/createBrowserHistory";
 import $ from "jquery";
 import MapApi from "./map_api";
 import mapboxgl from "mapbox-gl/dist/mapbox-gl.js";


### PR DESCRIPTION
issue: https://github.com/lonelyplanet/destinations-next/issues/1359
error: `TypeError: (0 , s.createHistory) is not a function`

History module was bumped here: https://github.com/lonelyplanet/rizzo-next/commit/d55f42579ad55fe19ea6f84c4dbe738b2e8107ae#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R51.
There is no named export called `createHistory` in history module any more.
Tested locally in destinations-next.