### PR TITLE
update: read variant value from user status endpoint

### DIFF
--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -2,6 +2,7 @@ import { Component } from "../../core/bane";
 import SearchComponent from "../search";
 import NavigationComponent from "../navigation";
 import NavigationState from "../navigation/navigation_state";
+import subscribe from "../../core/decorators/subscribe";
 import $ from "jquery";
 import debounce from "lodash/debounce";
 import BetaBannerComponent from "../beta_banner/beta_banner_component";
@@ -36,16 +37,23 @@ class Header extends Component {
 
     this.appendMenuIcon();
     this.buildGlobalComponents();
-    if(this.hasVariantCookie()) {
-      const $betaBanner = new BetaBannerComponent();
-      $betaBanner.render();
-    }
+
+
+    this.subscribe();
   }
 
   buildGlobalComponents() {
     $(document).on("touchstart", "a[href*='login']", () => {
       this.navigation._clickNav();
     });
+  }
+
+  @subscribe("user.status.update")
+  showBetaBanner(user) {
+    if(this.hasVariantCookie(user.variant)) {
+      const $betaBanner = new BetaBannerComponent();
+      $betaBanner.render();
+    }
   }
 
   /**
@@ -73,10 +81,10 @@ class Header extends Component {
    * If in variant group then show the beta banner
    * @return {Boolean}
    */
-  hasVariantCookie() {
+  hasVariantCookie(variant) {
     // Hard coding the specfic cookier for now just to make sure
     // to not interfere with other tests going on
-    return document.cookie.indexOf("split-16-connect") > -1;
+    return document.cookie.indexOf(variant) > -1;
   }
 
   onSearchClick(e) {

--- a/src/components/login/login_manager.js
+++ b/src/components/login/login_manager.js
@@ -47,7 +47,9 @@ export default class LoginManager {
    * @param  {Object} user User login information
    */
   statusFetched(user) {
-    this.user = (user.username ? new User(user) : new User());
+    // When swapping UI components through _v cookie being set with a specific value
+    // We need to instantiante the user with any variants being sent from the status check
+    this.user = (user.username ? new User(user) : new User({ variant: user.variant }));
 
     if (!user.id) {
       return this._updateStatus();

--- a/src/components/login/user.js
+++ b/src/components/login/user.js
@@ -12,6 +12,7 @@ export default class User {
     avatar = "http://dummyimage.com/80x80/4d494d/686a82.gif",
     messages = [],
     activity = [],
+    variant,
   } = {}) {
     this.id = id;
     this.email = email;
@@ -23,6 +24,7 @@ export default class User {
     this.activity = activity;
     this.luna = luna;
     this.connect = connect;
+    this.variant = variant;
     this.profileLink = connect ?
       `https://www.lonelyplanet.com/profile/${id}/edit` :
       `https://www.lonelyplanet.com/thorntree/profiles/${profileSlug}`;

--- a/src/components/navigation/navigation_component.js
+++ b/src/components/navigation/navigation_component.js
@@ -193,7 +193,7 @@ class NavigationComponent extends Component {
     let $mobileNavigationHeader = this.$mobileNavigation.find(".js-mobile-navigation-header");
 
     if (!user.id) {
-      if (this.showNewLoginLink()) {
+      if (this.showNewLoginLink(user.variant)) {
         // lp.require is a way to detect if this is a legacy app or not (/¯◡ ‿ ◡)/¯ ~ ┻━┻
         const loginLink = window.lp.require ? "https://connect.lonelyplanet.com" : "#login";
         this.$el.find(".navigation__link[href*='sign_in']").attr("href", loginLink);
@@ -224,8 +224,8 @@ class NavigationComponent extends Component {
     this.userStatusUpdate(user);
   }
 
-  showNewLoginLink() {
-    return document.cookie.indexOf("split-16-connect") > -1;
+  showNewLoginLink(variant) {
+    return document.cookie.indexOf(variant) > -1;
   }
 }
 


### PR DESCRIPTION
In the instance we need to do a rollback we need to be able to quickly update the value of the variant. 

This reads the variant value from the dotcom-connect user status endpoint so the value can be changed without redeploys. 