### PR TITLE
fix: delete variant cookie with proper domain

### DIFF
--- a/src/components/beta_banner/beta_banner_component.js
+++ b/src/components/beta_banner/beta_banner_component.js
@@ -29,8 +29,7 @@ export default class BetaBannerComponent {
   }
 
   leaveBeta() {
-    Cookie.remove("_v");// Remove Variant
-
+    Cookie.remove("_v", { domain: ".lonelyplanet.com" });// Remove Variant
     // give a little cushion before redirecting
     setTimeout(() => {
       window.location = "//connect.lonelyplanet.com/users/sign_out"; // Sign Out


### PR DESCRIPTION
the cookie value for the variant changed which domain it was being set to. Had to update the domain from which I remove the cookie