### PR TITLE
Remove check for MapComponent.supported to initialize map.

### DIFF
--- a/src/components/map/map_component.js
+++ b/src/components/map/map_component.js
@@ -16,10 +16,6 @@ export default class MapComponent extends Component {
   initialize() {
     rizzo.logger.log("Creating map");
 
-    if (!MapComponent.supported) {
-      return false;
-    }
-
     this.fetchMap();
 
     Arkham.on("map.closed", () => {

--- a/src/components/map_static/index.js
+++ b/src/components/map_static/index.js
@@ -18,7 +18,7 @@ $mapButton.on("click", function() {
         el: ".map_holder"
       });
 
-      if (!MapComponent.default.supported && map) {
+      if (map) {
         map.close();
       }
 


### PR DESCRIPTION
Since mapbox-gl was removed, this check will now always fail. 