### PR TITLE
Update property in article schema

### DIFF
--- a/src/components/article/article_schema.hbs
+++ b/src/components/article/article_schema.hbs
@@ -2,10 +2,7 @@
   {
     "@context": "http://schema.org",
     "@type": "Article",
-    "mainEntityOfPage": {
-      "@type": "WebPage",
-      "@id": "https://www.lonelyplanet.com/{{ article.slug }}"
-    },
+    "mainEntityOfPage": "https://www.lonelyplanet.com/{{ article.slug }}",
     "headline": "{{ article.title }}",
     "datePublished": "{{ article.post_date }}",
     "dateModified": "{{ article.post_date }}",


### PR DESCRIPTION
Change mainEntityOfPage to be a string that is the canonical URL of
the page. Fixes validation error in Google’s data testing tool.

https://github.com/lonelyplanet/destinations-next/issues/1374