### PR TITLE
fix: Update Scroll constructor call

### DIFF
--- a/src/components/scroll_to/scroll-to.js
+++ b/src/components/scroll_to/scroll-to.js
@@ -9,9 +9,7 @@ class ScrollToComponent extends Component {
       "click .js-action-scroll-to": "scrollLinkClicked"
     };
 
-    this._scroll = new Scroll({
-        el: document.body
-    });
+    this._scroll = new Scroll(document.body);
   }
 
   scrollLinkClicked(event) {


### PR DESCRIPTION
"The Best in Asia comp modal doesn't appear to be working for me and some others around"

It was introduced here:
https://github.com/lonelyplanet/rizzo-next/commit/d55f42579ad55fe19ea6f84c4dbe738b2e8107ae#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R69

Scroll constructor was changed: 
https://github.com/mkay581/scroll-js/commit/1e642327b91f740316bd78c1e20ebc0d4cde7632

and this:
https://github.com/lonelyplanet/marketing/blob/master/app/pages/best_in_asia/index.js#L45
https://github.com/lonelyplanet/rizzo-next/blob/master/src/components/scroll_to/scroll-to.js#L13
is throwing:
`Uncaught Error: Scroll error: element passed to Scroll constructor must be a DOM node, you passed [object Object]!`

preventing Modal constructor from being called below:
https://github.com/lonelyplanet/marketing/blob/master/app/pages/best_in_asia/index.js#L55

and detaching modal:
https://github.com/lonelyplanet/rizzo-next/blob/master/src/components/modal/modal_component.js#L24

so it's covering "ENTER COMPETITION" button, you can't click it (see attached image).