### PR TITLE
Updated Brightcove videos to query playlists/videos through Open Planet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -371,7 +371,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000709",
+        "caniuse-db": "1.0.30000712",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.17",
@@ -982,7 +982,7 @@
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "requires": {
         "babel-runtime": "6.25.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -1047,7 +1047,7 @@
       "requires": {
         "babel-core": "6.25.0",
         "babel-runtime": "6.25.0",
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
@@ -1059,7 +1059,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
       "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
       "requires": {
-        "core-js": "2.4.1",
+        "core-js": "2.5.0",
         "regenerator-runtime": "0.10.5"
       }
     },
@@ -1217,7 +1217,7 @@
         "content-type": "1.0.2",
         "debug": "2.6.7",
         "depd": "1.1.1",
-        "http-errors": "1.6.1",
+        "http-errors": "1.6.2",
         "iconv-lite": "0.4.15",
         "on-finished": "2.3.0",
         "qs": "6.4.0",
@@ -1265,7 +1265,7 @@
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.0.1",
+        "chalk": "2.1.0",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
@@ -1288,9 +1288,9 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -1382,7 +1382,7 @@
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
         "browserify-zlib": "0.1.4",
-        "buffer": "5.0.6",
+        "buffer": "5.0.7",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
         "console-browserify": "1.1.0",
@@ -1496,14 +1496,14 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000709",
-        "electron-to-chromium": "1.3.16"
+        "caniuse-db": "1.0.30000712",
+        "electron-to-chromium": "1.3.17"
       }
     },
     "buffer": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
-      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.7.tgz",
+      "integrity": "sha512-NeeHXWh5pCbPQCt2/6rLvXqapZfVsqw/YgRgaHpT3H9Uzgs+S0lSg5SQzouIuDvcmlQRqBe8hOO2scKCu3cxrg==",
       "requires": {
         "base64-js": "1.2.1",
         "ieee754": "1.1.8"
@@ -1597,7 +1597,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000709",
+        "caniuse-db": "1.0.30000712",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1611,9 +1611,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000709",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000709.tgz",
-      "integrity": "sha1-C2AAcrfNu/YzaodYtxua0DJo7eI=",
+      "version": "1.0.30000712",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000712.tgz",
+      "integrity": "sha1-iXSDlvnXQZ1fon3ztIhy2tv4MYo=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2124,26 +2124,15 @@
       }
     },
     "connect": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.2.tgz",
-      "integrity": "sha1-aU6NIGgb/kkCgsiriGvpjwn0L+c=",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
+      "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
       "dev": true,
       "requires": {
-        "debug": "2.6.7",
-        "finalhandler": "1.0.3",
+        "debug": "2.6.8",
+        "finalhandler": "1.0.4",
         "parseurl": "1.3.1",
         "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "console-browserify": {
@@ -2479,9 +2468,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
+      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -3088,9 +3077,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz",
-      "integrity": "sha1-0OAmc1dUdwkBrjAaIWZMukXZL30=",
+      "version": "1.3.17",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz",
+      "integrity": "sha1-QcE0V8xxZsXBXnZ65h2GqMrN7l0=",
       "dev": true
     },
     "elliptic": {
@@ -3638,9 +3627,9 @@
       }
     },
     "eslint": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.3.0.tgz",
-      "integrity": "sha1-/NfJY3a780yF7mftABKimWQrEI8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.4.0.tgz",
+      "integrity": "sha1-o+FT5wS2T3gpDvA1kklOq6Io07w=",
       "dev": true,
       "requires": {
         "ajv": "5.2.2",
@@ -3651,7 +3640,7 @@
         "debug": "2.6.8",
         "doctrine": "2.0.0",
         "eslint-scope": "3.7.1",
-        "espree": "3.4.3",
+        "espree": "3.5.0",
         "esquery": "1.0.0",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
@@ -3776,9 +3765,9 @@
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
+      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
         "acorn": "5.1.1",
@@ -4004,7 +3993,7 @@
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.18",
-        "jschardet": "1.5.0",
+        "jschardet": "1.5.1",
         "tmp": "0.0.31"
       }
     },
@@ -4223,29 +4212,18 @@
       }
     },
     "finalhandler": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
       "dev": true,
       "requires": {
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.1",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "find-cache-dir": {
@@ -6156,23 +6134,15 @@
       }
     },
     "http-errors": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
       "dev": true,
       "requires": {
-        "depd": "1.1.0",
+        "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
-          "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
-          "dev": true
-        }
       }
     },
     "http-proxy": {
@@ -6305,9 +6275,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -6327,7 +6297,7 @@
           "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
           "dev": true,
           "requires": {
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "source-map": "0.5.6",
             "supports-color": "4.2.1"
           }
@@ -6467,7 +6437,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
-        "chalk": "2.0.1",
+        "chalk": "2.1.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.1.0",
         "external-editor": "2.0.4",
@@ -6498,9 +6468,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -7072,9 +7042,9 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.0.tgz",
-      "integrity": "sha512-+Q8JsoEQbrdE+a/gg1F9XO92gcKXgpE5UACqr0sIubjDmBEkd+OOWPGzQeMrWSLxd73r4dHxBeRW7edHu5LmJQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
       "dev": true
     },
     "jsdom": {
@@ -7284,8 +7254,8 @@
         "chokidar": "1.7.0",
         "colors": "1.1.2",
         "combine-lists": "1.0.1",
-        "connect": "3.6.2",
-        "core-js": "2.4.1",
+        "connect": "3.6.3",
+        "core-js": "2.5.0",
         "di": "0.0.1",
         "dom-serialize": "2.2.1",
         "expand-braces": "0.1.2",
@@ -9572,9 +9542,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9594,7 +9564,7 @@
           "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
           "dev": true,
           "requires": {
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "source-map": "0.5.6",
             "supports-color": "4.2.1"
           }
@@ -9630,9 +9600,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9652,7 +9622,7 @@
           "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
           "dev": true,
           "requires": {
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "source-map": "0.5.6",
             "supports-color": "4.2.1"
           }
@@ -9688,9 +9658,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9710,7 +9680,7 @@
           "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
           "dev": true,
           "requires": {
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "source-map": "0.5.6",
             "supports-color": "4.2.1"
           }
@@ -9746,9 +9716,9 @@
           }
         },
         "chalk": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-          "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
@@ -9768,7 +9738,7 @@
           "integrity": "sha512-G6WnRmdTt2jvJvY+aY+M0AO4YlbxE+slKPZb+jG2P2U9Tyxi3h1fYZ/DgiFU6DC6bv3XIEJoZt+f/kNh8BrWFw==",
           "dev": true,
           "requires": {
-            "chalk": "2.0.1",
+            "chalk": "2.1.0",
             "source-map": "0.5.6",
             "supports-color": "4.2.1"
           }

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -28,7 +28,12 @@ class Brightcove extends VideoPlayer {
   play() {
     super.play();
     this.autoplay = true;
-    this.player.play();
+    const promise = this.player.play();
+
+    // Catch any errors thrown within play promise (only applicable on some browsers)
+    if (promise) {
+      promise.catch(reason => console.log('VIDEOJS:', reason)).then(() => {});
+    }
   }
 
   pause() {
@@ -39,12 +44,15 @@ class Brightcove extends VideoPlayer {
 
   start() {
     this.currentVideoIndex = null;
+    this.autoplay = true;
     this.loadNextVideo();
-    this.play();
   }
 
   setup() {
-    if (!this.videoEl) {
+    if (!this.videoId) {
+      this.trigger("ready");
+    }
+    else if (!this.videoEl) {
       // Insert brightcove player html
       let html = "<video ";
       if (this.videoId) {
@@ -68,7 +76,7 @@ class Brightcove extends VideoPlayer {
       script.onload = this.onLoadSetupScript.bind(this);
 
       document.body.appendChild(script);
-    } else {
+    } else if (!this.player) {
       this.player = videojs(this.videoEl);
 
       // We don't show the controls until the player is instantiated
@@ -100,10 +108,6 @@ class Brightcove extends VideoPlayer {
     this.trigger("disposed", this);
   }
 
-  isReady() {
-    return this.player && this.player.isReady_;
-  }
-
   getPlayerScriptId() {
     return "video__initialize-" + this.playerId;
   }
@@ -113,6 +117,8 @@ class Brightcove extends VideoPlayer {
   }
 
   onPlayerReady() {
+    this.currentVideoIndex = null;
+    this.loadNextVideo();
     this.trigger("ready");
   }
 
@@ -160,7 +166,7 @@ class Brightcove extends VideoPlayer {
     this.trigger("loadstart");
 
     if (this.autoplay) {
-      this.player.play();
+      this.play();
     }
   }
 
@@ -196,34 +202,42 @@ class Brightcove extends VideoPlayer {
   }
 
   fetchVideos() {
-    if (!this.player) {
-      return Promise.resolve(false);
-    }
 
     let query = null;
     try {
-      query = "ref:dest_" + window.lp.place.atlasId;
+      query = "dest_" + window.lp.place.atlasId;
     }
     catch (e) {
       return Promise.resolve(false);
     }
 
     return new Promise((resolve) => {
-      this.player.catalog.getPlaylist(query, (error, playlist) => {
-        if (!error) {
-          this.videos = playlist.length ? playlist : [];
+      $.ajax({
+        url: "https://www.lonelyplanet.com/video/api/playlists.json?reference_id=" + query
+      }).done((data, status, response) => {
+        if (response.status === 200 && data && data.length) {
+          this.videos = data[0].playlistitems.map(item => item.video);
         }
 
         if (this.videos.length) {
           this.loadNextVideo();
           resolve(true);
-        } else {
-          this.player.catalog.getVideo(query, (error, video) => {
-            if (!error) {
-              this.videos = [video];
-              this.loadNextVideo();
+        }
+        else {
+          $.ajax({
+            url: "https://www.lonelyplanet.com/video/api/video.json?reference_id=" + query
+          }).done((data, status, response) => {
+            if (response.status === 200 && data && data.length) {
+              this.videos = data;
             }
-            resolve(!error);
+
+            if (this.videos.length) {
+              this.loadNextVideo();
+              resolve(true);
+            }
+            else {
+              resolve(false);
+            }
           });
         }
       });
@@ -231,7 +245,7 @@ class Brightcove extends VideoPlayer {
   }
 
   loadNextVideo() {
-    if (!this.player || !this.videos.length) {
+    if (!this.videos.length) {
       return;
     }
 
@@ -240,10 +254,21 @@ class Brightcove extends VideoPlayer {
 
     const video = this.videos[this.currentVideoIndex];
 
-    // Do not load a video that is already loaded
-    // (brightcove's engagement score metrics will break)
-    if (!this.player.mediainfo || (this.player.mediainfo.id !== video.id)) {
-      this.player.catalog.load(video);
+    if (!this.player) {
+      this.videoId = video.provider_id;
+      this.setup();
+    }
+    else if (!this.player.mediainfo || (this.player.mediainfo.id !== video.provider_id)) {
+      // Do not load a video that is already loaded
+      // (brightcove's engagement score metrics will break)
+      this.player.catalog.getVideo(video.provider_id, (error, video) => {
+        if (!error) {
+          this.player.catalog.load(video);
+        }
+      });
+    }
+    else if (this.autoplay) {
+      this.play();
     }
   }
 

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -32,7 +32,7 @@ class Brightcove extends VideoPlayer {
 
     // Catch any errors thrown within play promise (only applicable on some browsers)
     if (promise) {
-      promise.catch(reason => console.log('VIDEOJS:', reason)).then(() => {});
+      promise.catch(reason => console.log("VIDEOJS:", reason)).then(() => {});
     }
   }
 

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -211,9 +211,11 @@ class Brightcove extends VideoPlayer {
       return Promise.resolve(false);
     }
 
+    const apiURL = "https://www.lonelyplanet.com/video/api/";
+
     return new Promise((resolve) => {
       $.ajax({
-        url: "https://www.lonelyplanet.com/video/api/playlists.json?reference_id=" + query
+        url: apiURL + "playlists.json?reference_id=" + query
       }).done((data, status, response) => {
         if (response.status === 200 && data && data.length) {
           this.videos = data[0].playlistitems.map(item => item.video);
@@ -225,7 +227,7 @@ class Brightcove extends VideoPlayer {
         }
         else {
           $.ajax({
-            url: "https://www.lonelyplanet.com/video/api/video.json?reference_id=" + query
+            url: apiURL + "video.json?reference_id=" + query
           }).done((data, status, response) => {
             if (response.status === 200 && data && data.length) {
               this.videos = data;

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -39,7 +39,7 @@ class Video {
     // Take the return value and use .then() on it to ensure the
     // player is ready before using it.
     return new Promise((resolve) => {
-      if (player.isReady()) {
+      if (player.isReady) {
         resolve(player);
         return;
       }

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -8,11 +8,9 @@ class VideoPlayer extends Component {
     this.autoplay = autoplay;
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
+    this.isReady = false;
+    this.on("ready", () => { this.isReady = true; });
     this.setup();
-  }
-
-  isReady() {
-    return true;
   }
 
   /**

--- a/src/components/video_overlay/video_overlay_component.js
+++ b/src/components/video_overlay/video_overlay_component.js
@@ -67,18 +67,14 @@ export default class VideoOverlay extends Overlay {
   */
   playerReady (player) {
     this.player = player;
-    this.player.fetchVideos().then(this.fetchDone.bind(this));
+    this.listenTo(this.player, "loadstart", this.onPlayerLoadStart.bind(this));
+    this.player.fetchVideos();
   }
 
   /**
-  * Callback from the player loadVideo()
-  * @param  {bool} success - depicting whether at least one video is available or not
-  */
-  fetchDone (success) {
-    if (!success) {
-      return;
-    }
-
-    this.trigger("video.loaded");
+   * Callback from the player "loadstart" event / when a video is loaded and is ready to play.
+   */
+  onPlayerLoadStart() {
+    this.calculateDimensions();
   }
 }

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -1,6 +1,5 @@
 import { Component } from "../../core/bane";
 import Video from "../video";
-import VideoOverlay from "../video_overlay";
 
 /**
  * Video Poster Button Component
@@ -14,7 +13,6 @@ export default class VideoPosterButtonComponent extends Component {
     };
 
     Video.addPlayer(this.$el.find(".video-poster-button__video")[0]).then(this.playerReady.bind(this));
-    (new VideoOverlay({el:document.getElementsByClassName('video-overlay')[0]})).show();
   }
 
   showVideo() {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -1,5 +1,6 @@
 import { Component } from "../../core/bane";
 import Video from "../video";
+import VideoOverlay from "../video_overlay";
 
 /**
  * Video Poster Button Component
@@ -13,6 +14,7 @@ export default class VideoPosterButtonComponent extends Component {
     };
 
     Video.addPlayer(this.$el.find(".video-poster-button__video")[0]).then(this.playerReady.bind(this));
+    (new VideoOverlay({el:document.getElementsByClassName('video-overlay')[0]})).show();
   }
 
   showVideo() {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -100,7 +100,7 @@ export default class VideoPosterButtonComponent extends Component {
     this.player = player;
     this.listenTo(this.player, "ended", this.onPlayerEnded.bind(this));
     this.listenTo(this.player, "loadstart", this.onPlayerLoadStart.bind(this));
-    this.player.fetchVideos().then(this.fetchDone.bind(this));
+    this.player.fetchVideos();
   }
 
   /**
@@ -114,18 +114,6 @@ export default class VideoPosterButtonComponent extends Component {
    * Callback from the player "loadstart" event / when a video is loaded and is ready to play.
    */
   onPlayerLoadStart() {
-    this.renderText();
-  }
-
-  /**
-  * Callback from the player fetchVideos()
-  * @param  {bool} success - depicting whether at least one video is available or not
-  */
-  fetchDone(success) {
-    if (!success) {
-      return;
-    }
-
     this.render();
   }
 }


### PR DESCRIPTION
This should clean up a lot of the console error clutter:
- No longer uses Brightcove's API -- No more 404 errors
- Added error handling around videojs.play() -- No more "play interrupted" errors
- Video embed isn't created unless we have a video to load -- No more "videojs-contrib-ad" errors