### PR TITLE
feat: add user id to dataLayer globally

### DIFF
--- a/src/components/login/login_manager.js
+++ b/src/components/login/login_manager.js
@@ -40,6 +40,23 @@ export default class LoginManager {
       this.statusFetched(user);
     });
   }
+
+   /**
+   * Sets user id to dataLayer for analytics
+   * @return null
+   */
+  setDataLayer(id) {
+    if(
+      window &&
+      window.lp &&
+      window.lp.analytics &&
+      window.lp.analytics.dataLayer &&
+      window.lp.analytics.dataLayer.length
+    ){
+      window.lp.analytics.dataLayer[0].accountId = id;
+    }
+  }
+
   /**
    * Callback from checking the user's login status.
    * If the user is not logged in, it will publish a user with a null id.
@@ -55,6 +72,7 @@ export default class LoginManager {
       return this._updateStatus();
     }
 
+    this.setDataLayer(user.id);
     this._updateStatus();
   }
 

--- a/src/components/login/user.js
+++ b/src/components/login/user.js
@@ -40,6 +40,7 @@ export default class User {
     if (window.lp.auth && window.lp.auth.host) {
       this.signOutLink = `${window.lp.auth.host}/users/sign_out`;
     }
+
   }
   toJSON() {
     let obj = {};


### PR DESCRIPTION
instead of setting user id to data layer app by app, this pr will set the id globally when user logs in

resolves https://github.com/lonelyplanet/dotcom-profile/issues/166