### PR TITLE
Updated Video components for Best in Travel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rizzo-next",
-  "version": "0.26.5",
+  "version": "0.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11143,46 +11143,6 @@
       "requires": {
         "hash-base": "2.0.2",
         "inherits": "2.0.3"
-      }
-    },
-    "rizzo-next": {
-      "version": "0.26.4",
-      "resolved": "https://registry.npmjs.org/rizzo-next/-/rizzo-next-0.26.4.tgz",
-      "integrity": "sha512-FqFQAtf3GMriNMfsppaR4y8Q3ktP9M35qijMrm0NL/pc9hKwaGj0KIjlV8do6yCnLowJVNF8PMCZ1oxFVebgew==",
-      "requires": {
-        "@lonelyplanet/dotcom-core": "2.0.3",
-        "airbrake-js": "0.9.4",
-        "async": "2.5.0",
-        "babel-core": "6.25.0",
-        "babel-polyfill": "6.23.0",
-        "clamp-js": "0.7.0",
-        "commander": "2.11.0",
-        "es5-shim": "4.5.9",
-        "flamsteed": "0.0.4",
-        "glob": "7.1.2",
-        "handlebars": "4.0.10",
-        "history": "4.6.3",
-        "imagesloaded": "4.1.3",
-        "jquery": "3.2.1",
-        "jquery.dfp": "2.4.2",
-        "js-cookie": "2.1.4",
-        "lodash": "4.17.4",
-        "mapbox.js": "3.1.1",
-        "matchmedia-polyfill": "0.3.0",
-        "mkdirp": "0.5.1",
-        "moment": "2.18.1",
-        "owlcarousel-pre": "1.3.3",
-        "photoswipe": "4.1.2",
-        "pickadate": "3.5.6",
-        "picturefill": "3.0.2",
-        "postal": "2.0.5",
-        "react": "15.6.1",
-        "react-dom": "15.6.1",
-        "resrc.js": "0.9.5",
-        "scroll-js": "1.7.1",
-        "susy": "2.2.12",
-        "trackjs": "2.8.4",
-        "urlencode": "1.1.0"
       }
     },
     "run-async": {

--- a/src/components/sub_nav/_sub_nav.scss
+++ b/src/components/sub_nav/_sub_nav.scss
@@ -39,7 +39,7 @@ $navigation-sub-height-mobile: $header-height-mobile;
     position: fixed;
     right: 0;
     top: 0;
-    z-index: z("top");
+    z-index: z("top") + 1;
   }
 
   &.is-bottom {

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -1,5 +1,11 @@
 @import "../../../sass/webpack_deps";
 
+video {
+  height: 100%;
+  margin: 0 auto;
+  width: 100%;
+}
+
 .video-js {
   height: 100%;
   margin: 0 auto;

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -16,6 +16,11 @@ video {
     top: 0;
   }
 
+  .vjs-overlay-top-right {
+    right: 0;
+    top: 0;
+  }
+
   .vjs-overlay-bottom {
     left: 0;
     margin-left: 0;
@@ -59,5 +64,73 @@ video {
     position: absolute;
     top: 0;
     width: 100%;
+  }
+}
+
+.video__popout {
+  width: 100%;
+  height: 100%;
+
+  &__inner {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: opacity 200ms ease;
+    opacity: 0;
+
+    &-visible {
+      opacity: 1;
+    }
+
+    .video__popout-overlay {
+      position: absolute;
+      right: 0px;
+      top: -30px;
+      opacity: 0;
+      background-color: rgba($color-black, .45);
+      color: $color-white;
+      font-size: 10px;
+      font-weight: 600;
+      padding: .7em;
+      cursor: pointer;
+      transition: top 1s ease, opacity 200ms ease;
+      z-index: 1;
+    }
+
+    &-poppedout {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      position: fixed;
+      z-index: 1;
+      width: 60%;
+      max-width: 406px;
+      height: initial;
+      box-shadow: 0px 1px 8px 0px rgba(0, 0, 0, .4);
+
+      .video-js {
+        padding-top: 56.25% /* 16:9 */
+      }
+
+      .video__popout-overlay  {
+        opacity: 1;
+      }
+    }
+
+    &-hover {
+      .video__popout-overlay  {
+        top: 0px;
+      }
+      .vjs-control-bar {
+        transform: translateY(0) !important;
+      }
+    }
+  }
+}
+
+.video--adplaying {
+  .video__popout-overlay {
+    display: none;
   }
 }

--- a/src/components/video/_video.scss
+++ b/src/components/video/_video.scss
@@ -28,6 +28,12 @@ video {
     width: 100%;
   }
 
+  // scss-lint:disable ImportantRule
+  .vjs-control-bar {
+    transition: transform 200ms ease !important;
+  }
+  // scss-lint:enable ImportantRule
+
   .vjs-big-play-button {
     @media (max-width: $max-480) {
       transform: scale(.7);
@@ -68,69 +74,93 @@ video {
 }
 
 .video__popout {
-  width: 100%;
   height: 100%;
+  width: 100%;
+}
 
-  &__inner {
-    overflow: hidden;
-    position: relative;
-    width: 100%;
-    height: 100%;
-    transition: opacity 200ms ease;
+.video__popout-inner {
+  height: 100%;
+  opacity: 0;
+  overflow: hidden;
+  position: relative;
+  transition: opacity 200ms ease;
+  width: 100%;
+
+
+  &-visible {
+    opacity: 1;
+  }
+
+  .video__popout-overlay {
+    background-color: rgba($color-black, .45);
+    color: $color-white;
+    cursor: pointer;
+    font-size: 10px;
+    font-weight: 600;
     opacity: 0;
+    padding: .7em;
+    position: absolute;
+    right: 0;
+    top: -30px;
+    transition: top 200ms ease, opacity 200ms ease;
+    z-index: 1;
+  }
 
-    &-visible {
-      opacity: 1;
+  &-poppedout {
+    bottom: 20px;
+    box-shadow: 0 1px 8px 0 rgba($color-black, .4);
+    height: initial;
+    max-width: 406px;
+    position: fixed;
+    right: 20px;
+    width: 60%;
+    z-index: 1;
+
+    .video-js {
+      padding-top: 56.25%; // 16:9
     }
 
     .video__popout-overlay {
-      position: absolute;
-      right: 0px;
-      top: -30px;
-      opacity: 0;
-      background-color: rgba($color-black, .45);
-      color: $color-white;
-      font-size: 10px;
-      font-weight: 600;
-      padding: .7em;
-      cursor: pointer;
-      transition: top 1s ease, opacity 200ms ease;
-      z-index: 1;
+      opacity: 1;
+    }
+  }
+
+  &-hover {
+    .video__popout-overlay {
+      top: 0;
     }
 
-    &-poppedout {
-      position: fixed;
-      right: 20px;
-      bottom: 20px;
-      position: fixed;
-      z-index: 1;
-      width: 60%;
-      max-width: 406px;
-      height: initial;
-      box-shadow: 0px 1px 8px 0px rgba(0, 0, 0, .4);
-
-      .video-js {
-        padding-top: 56.25% /* 16:9 */
-      }
-
-      .video__popout-overlay  {
-        opacity: 1;
-      }
+    // scss-lint:disable ImportantRule
+    .vjs-control-bar {
+      transform: translateY(0) !important;
     }
-
-    &-hover {
-      .video__popout-overlay  {
-        top: 0px;
-      }
-      .vjs-control-bar {
-        transform: translateY(0) !important;
-      }
-    }
+    // scss-lint:enable ImportantRule
   }
 }
 
-.video--adplaying {
+.video__adplaying {
   .video__popout-overlay {
     display: none;
   }
+}
+
+.video__cover--container {
+  overflow: hidden;
+  position: relative;
+
+  // scss-lint:disable ImportantRule
+  .video-js,
+  video {
+    height: auto !important;
+    left: 50% !important;
+    min-height: 100%;
+    min-width: 100%;
+    overflow: hidden;
+    position: absolute;
+    top: 50% !important;
+    transform: translateX(-50%) translateY(-50%);
+    width: auto !important;
+    z-index: -1000;
+  }
+  // scss-lint:enable ImportantRule
 }

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -2,12 +2,27 @@
 
 import VideoPlayer from "./video_player";
 
+const bcPlayerIds = {
+  default: "default",
+  background: "BJputewob",
+  bestintravel: "HkJcclwoZ",
+  destinations: "HkPdqeDiZ",
+};
+
 class Brightcove extends VideoPlayer {
   initialize(options) {
-    super.initialize(options);
+    options = options || {};
+
+    this.player = null;
 
     this.videos = [];
     this.currentVideoIndex = null;
+
+    this.bcAccountId = "5104226627001";
+    this.bcEmbedId = "default";
+    this.bcPlayerId = bcPlayerIds[options.playerName];
+
+    super.initialize(options);
 
     this.events["click .video-js"] = "onClickVideo";
   }
@@ -59,8 +74,8 @@ class Brightcove extends VideoPlayer {
         html += "data-video-id='" + this.videoId + "' ";
       }
       html += "data-account='5104226627001' ";
-      html += "data-player='default' ";
-      html += "data-embed='default' ";
+      html += "data-player='" + this.bcPlayerId + "' ";
+      html += "data-embed='" + this.bcEmbedId + "' ";
       html += "data-application-id ";
       html += "class='video-js' ";
       html += "></video>";
@@ -68,7 +83,7 @@ class Brightcove extends VideoPlayer {
 
       // Insert script to initialize brightcove player
       const scriptId = this.getPlayerScriptId();
-      const scriptSrc = "https://players.brightcove.net/5104226627001/default_default/index.min.js";
+      const scriptSrc = "https://players.brightcove.net/" + this.bcAccountId + "/" + this.bcPlayerId + "_" + this.bcEmbedId + "/index.min.js";
       const script = document.createElement("script");
 
       script.id = scriptId;
@@ -80,8 +95,8 @@ class Brightcove extends VideoPlayer {
       this.player = videojs(this.videoEl);
 
       // We don't show the controls until the player is instantiated
-      // or else the controls show briefly without the brightcove theme applied.
-      this.player.controls(true);
+      // or else the controls show briefly without the brightcove theme applied.{
+      this.player.controls(this.controls);
 
       this.player.on("loadstart", this.onPlayerLoadStart.bind(this));
       this.player.on("playing", this.onPlayerPlaying.bind(this));
@@ -394,7 +409,7 @@ class Brightcove extends VideoPlayer {
    * This is run automatically when any video is loaded.
    */
   renderSEOMarkup() {
-    if (!this.player || !this.player.mediainfo) {
+    if (!this.seo || !this.player || !this.player.mediainfo) {
       return;
     }
 
@@ -418,7 +433,7 @@ class Brightcove extends VideoPlayer {
     let seconds = Math.ceil(this.getVideoProperty("duration"));
     let duration = "PT" + seconds + "S";
 
-    let embedUrl = "https://players.brightcove.net/5104226627001/default_default/index.html?videoId=" + videoId;
+    let embedUrl = "https://players.brightcove.net/" + this.bcAccountId + "/" + this.bcPlayerId + "_" + this.bcEmbedId + "/index.html?videoId=" + videoId;
 
     let data = {
       "@context": "http://schema.org",

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -1,6 +1,9 @@
 /* global videojs */
 
 import VideoPlayer from "./video_player";
+import { get } from "lodash";
+
+const _ = { get };
 
 const bcPlayerIds = {
   default: "default",
@@ -23,19 +26,28 @@ class Brightcove extends VideoPlayer {
     this.bcEmbedId = "default";
     this.bcPlayerId = bcPlayerIds[options.playerName];
 
+    // Whether the player is within the viewport or not
+    this.inView = this.isInView();
+
     // Popout props
-    this.popoutEnabled = false;
-    this.outOfViewTimeoutId = null;
-    this.inViewTimeoutId = null;
-    this.inView = false;
+    this.popoutEnabled = false; // overrides this.popout (ex. player won't popout if it's not current playing)
+    this.isPoppedOut = false; // whether the player is poppout out currently or not
+    this.popoutOutOfViewTimeoutId = null;
+    this.popoutInViewTimeoutId = null;
 
     super.initialize(options);
 
     this.events["click .video-js"] = "onClickVideo";
 
-    if (this.popout) {
-      this.updatePopout.bind(this)();
-      window.addEventListener("scroll", this.updatePopout.bind(this));
+    window.addEventListener("scroll", this.onWindowScroll.bind(this));
+  }
+
+  set(options) {
+    this.autoplay = _.get(options, "autoplay", this.autoplay);
+
+    const videoId = _.get(options, "videoId", null);
+    if (videoId) {
+      this.loadVideo(videoId);
     }
   }
 
@@ -46,39 +58,93 @@ class Brightcove extends VideoPlayer {
     return this.$el.find(".video-js")[0];
   }
 
-  updatePopout() {
-    const bounds = this.el.getBoundingClientRect();
-    const halfContainerHeight = this.el.clientHeight / 2;
-    const popoutInner = this.$el.find(".video__popout__inner");
+  onWindowScroll() {
+    const inView = this.isInView();
+    if (!this.inView && inView) {
+      this.onInView();
+    }
+    else if (this.inView && !inView) {
+      this.onOutOfView();
+    }
+    this.inView = inView;
+  }
 
-    if (this.popoutEnabled && (bounds.top < -(halfContainerHeight))) {
-      if (this.inView) {
-        clearInterval(this.inViewTimeoutId);
-        this.inViewTimeoutId = null;
-        if (!this.outOfViewTimeoutId) {
-          popoutInner.removeClass("video__popout__inner-visible");
-          this.outOfViewTimeoutId = setTimeout(() => {
-            popoutInner.addClass("video__popout__inner-poppedout").addClass("video__popout__inner-visible");
-            this.outOfViewTimeoutId = null;
-          }, 200);
-        }
-      }
-      this.inView = false;
+  updatePopout() {
+    if (this.popoutEnabled && this.isAboveViewport()) {
+      this.showPopout();
     }
     else {
-      if (!this.inView) {
-        clearInterval(this.outOfViewTimeoutId);
-        this.outOfViewTimeoutId = null;
-        if (!this.inViewTimeoutId) {
-          popoutInner.removeClass("video__popout__inner-visible");
-          this.inViewTimeoutId = setTimeout(() => {
-            popoutInner.removeClass("video__popout__inner-poppedout").addClass("video__popout__inner-visible");
-            this.inViewTimeoutId = null;
-          }, 200);
-        }
-      }
-      this.inView = true;
+      this.hidePopout();
     }
+  }
+
+  showPopout() {
+    if (!this.popout || this.isPoppedOut) {
+      return;
+    }
+
+    this.isPoppedOut = true;
+    const popoutInner = this.$el.find(".video__popout-inner");
+
+    clearInterval(this.popoutInViewTimeoutId);
+    this.popoutInViewTimeoutId = null;
+    if (!this.popoutOutOfViewTimeoutId) {
+      popoutInner.removeClass("video__popout-inner-visible");
+      this.popoutOutOfViewTimeoutId = setTimeout(() => {
+        popoutInner.addClass("video__popout-inner-poppedout").addClass("video__popout-inner-visible");
+        this.popoutOutOfViewTimeoutId = null;
+      }, 200);
+    }
+  }
+
+  hidePopout() {
+    if (!this.popout || !this.isPoppedOut) {
+      return;
+    }
+
+    this.isPoppedOut = false;
+    const popoutInner = this.$el.find(".video__popout-inner");
+
+    clearInterval(this.popoutOutOfViewTimeoutId);
+    this.popoutOutOfViewTimeoutId = null;
+    if (!this.popoutInViewTimeoutId) {
+      popoutInner.removeClass("video__popout-inner-visible");
+      this.popoutInViewTimeoutId = setTimeout(() => {
+        popoutInner.removeClass("video__popout-inner-poppedout").addClass("video__popout-inner-visible");
+        this.popoutInViewTimeoutId = null;
+      }, 200);
+    }
+  }
+
+  onInView() {
+    this.updatePopout();
+
+    if (this.playWhenInView) {
+      this.play();
+      this.playWhenInView = false;
+    }
+  }
+
+  onOutOfView() {
+    this.updatePopout();
+  }
+
+  isInView() {
+    return !this.isAboveViewport() && !this.isBelowViewport();
+  }
+
+  isBelowViewport() {
+    const bounds = this.el.getBoundingClientRect();
+    const halfContainerHeight = bounds.height / 2;
+    const windowHeight = window.innerHeight;
+    return bounds.top > (windowHeight - halfContainerHeight);
+
+  }
+
+  isAboveViewport() {
+    const bounds = this.el.getBoundingClientRect();
+    const halfContainerHeight = bounds.height / 2;
+    return bounds.top < -(halfContainerHeight);
   }
 
   onClickVideo(event) {
@@ -91,8 +157,6 @@ class Brightcove extends VideoPlayer {
     super.play();
     this.autoplay = true;
     const promise = this.player.play();
-
-    // Catch any errors thrown within play promise (only applicable on some browsers)
     if (promise) {
       promise.catch(reason => console.log("VIDEOJS:", reason)).then(() => {});
     }
@@ -117,7 +181,11 @@ class Brightcove extends VideoPlayer {
     else if (!this.videoEl) {
       // Insert brightcove player html
       let html = "<div class='video__popout'>";
-      html += "<div class='video__popout__inner video__popout__inner-visible'>";
+      html += "<div class='video__popout-inner video__popout-inner-visible ";
+      if (this.cover) {
+        html += "video__cover--container ";
+      }
+      html += "' >";
 
       if (this.popout) {
         html += "<div id=\"" + this.getPopoutOverlayId() + "\" class=\"video__popout-overlay icon-close-small\" ></div>";
@@ -139,12 +207,12 @@ class Brightcove extends VideoPlayer {
 
       // Bind hover class as we style various things under this class
       // and :hover doesn't bubble
-      this.$el.find(".video__popout__inner")
+      this.$el.find(".video__popout-inner")
       .mouseenter(function () {
-        $(this).addClass("video__popout__inner-hover");
+        $(this).addClass("video__popout-inner-hover");
       })
       .mouseleave(function() {
-        $(this).removeClass("video__popout__inner-hover");
+        $(this).removeClass("video__popout-inner-hover");
       });
 
       // Bind click handler to X button for popout
@@ -166,6 +234,8 @@ class Brightcove extends VideoPlayer {
       // We don't show the controls until the player is instantiated
       // or else the controls show briefly without the brightcove theme applied.{
       this.player.controls(this.controls);
+
+      this.player.muted(this.muted);
 
       this.player.on("loadstart", this.onPlayerLoadStart.bind(this));
       this.player.on("playing", this.onPlayerPlaying.bind(this));
@@ -192,6 +262,8 @@ class Brightcove extends VideoPlayer {
       this.player = null;
     }
 
+    this.$el.html("");
+
     this.trigger("disposed", this);
   }
 
@@ -207,6 +279,11 @@ class Brightcove extends VideoPlayer {
     this.currentVideoIndex = null;
     this.loadNextVideo();
     this.trigger("ready");
+
+    if (this.isInView() && this.playWhenInView) {
+      this.play();
+      this.playWhenInView = false;
+    }
   }
 
   onPlayerCueChange() {
@@ -263,10 +340,11 @@ class Brightcove extends VideoPlayer {
     this.popoutEnabled = true;
     this.updatePopout();
     this.$el.removeClass("video__adplaying");
+    this.trigger("started");
   }
 
   onPlayerPause() {
-    if (this.inView) {
+    if (this.isInView()) {
       this.popoutEnabled = false;
       this.updatePopout();
     }
@@ -289,7 +367,7 @@ class Brightcove extends VideoPlayer {
   }
 
   onAdPause() {
-    if (this.inView) {
+    if (this.isInView()) {
       this.popoutEnabled = false;
       this.updatePopout();
     }
@@ -301,6 +379,7 @@ class Brightcove extends VideoPlayer {
     this.popoutEnabled = true;
     this.updatePopout();
     this.$el.addClass("video__adplaying");
+    this.trigger("started");
   }
 
   onAdEnded() {
@@ -335,7 +414,6 @@ class Brightcove extends VideoPlayer {
   }
 
   fetchVideos() {
-
     let query = null;
     try {
       query = "dest_" + window.lp.place.atlasId;
@@ -379,6 +457,25 @@ class Brightcove extends VideoPlayer {
     });
   }
 
+  loadVideo(videoId) {
+    if (!this.player) {
+      this.videoId = videoId;
+      this.setup();
+    }
+    else if (!this.player.mediainfo || (this.player.mediainfo.id !== videoId)) {
+      // Do not load a video that is already loaded
+      // (brightcove's engagement score metrics will break)
+      this.player.catalog.getVideo(videoId, (error, video) => {
+        if (!error) {
+          this.player.catalog.load(video);
+        }
+      });
+    }
+    else if (this.autoplay) {
+      this.play();
+    }
+  }
+
   loadNextVideo() {
     if (!this.videos.length) {
       return;
@@ -389,22 +486,7 @@ class Brightcove extends VideoPlayer {
 
     const video = this.videos[this.currentVideoIndex];
 
-    if (!this.player) {
-      this.videoId = video.provider_id;
-      this.setup();
-    }
-    else if (!this.player.mediainfo || (this.player.mediainfo.id !== video.provider_id)) {
-      // Do not load a video that is already loaded
-      // (brightcove's engagement score metrics will break)
-      this.player.catalog.getVideo(video.provider_id, (error, video) => {
-        if (!error) {
-          this.player.catalog.load(video);
-        }
-      });
-    }
-    else if (this.autoplay) {
-      this.play();
-    }
+    this.loadVideo(video.provider_id);
   }
 
   /**
@@ -467,7 +549,7 @@ class Brightcove extends VideoPlayer {
   }
 
   configureOverlays() {
-    if (!this.player) {
+    if (!this.player || !this.player.overlay) {
       return;
     }
 

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -13,8 +13,7 @@ const bcPlayerIds = {
 };
 
 class Brightcove extends VideoPlayer {
-  initialize(options) {
-    options = options || {};
+  initialize(options = {}) {
 
     // Playlist props
     this.videos = [];
@@ -403,16 +402,6 @@ class Brightcove extends VideoPlayer {
     adOverlay.css("display", "none");
   }
 
-  enablePopoutOverlay() {
-    const popoutOverlay = this.$el.find("#" + this.getPopoutOverlayId());
-    popoutOverlay.css("display", "inline-block");
-  }
-
-  disablePopoutOverlay() {
-    const popoutOverlay = this.$el.find("#" + this.getPopoutOverlayId());
-    popoutOverlay.css("display", "inline-block");
-  }
-
   fetchVideos() {
     let query = null;
     try {
@@ -637,7 +626,7 @@ class Brightcove extends VideoPlayer {
     let seconds = Math.ceil(this.getVideoProperty("duration"));
     let duration = "PT" + seconds + "S";
 
-    let embedUrl = "https://players.brightcove.net/" + this.bcAccountId + "/" + this.bcPlayerId + "_" + this.bcEmbedId + "/index.html?videoId=" + videoId;
+    let embedUrl = "https://players.brightcove.net/" + this.bcAccountId + "/default_" + this.bcEmbedId + "/index.html?videoId=" + videoId;
 
     let data = {
       "@context": "http://schema.org",

--- a/src/components/video/file.js
+++ b/src/components/video/file.js
@@ -11,12 +11,20 @@ class File extends VideoPlayer {
     if (this.videoId) {
       let html = "<video preload='auto' src='" + this.videoId + "' ";
 
+      if (this.cover) {
+        html += "class='video__cover' ";
+      }
+
       if (this.controls) {
-        html += " controls ";
+        html += "controls ";
+      }
+
+      if (this.muted) {
+        html += "muted ";
       }
 
       if (this.autoplay) {
-        html += " autoplay ";
+        html += "autoplay ";
       }
 
       if (this.poster) {
@@ -27,7 +35,13 @@ class File extends VideoPlayer {
 
       this.$el.html(html);
 
+      if (this.cover) {
+        this.$el.addClass("video__cover--container");
+      }
+
       this.player = this.el.getElementsByTagName("video")[0];
+      this.player.on("playing", () => { this.trigger("started"); });
+      this.player.on("ended", () => { this.trigger("ended"); });
     }
     super.setup();
   }
@@ -35,7 +49,10 @@ class File extends VideoPlayer {
   play() {
     super.play();
     if (this.player) {
-      this.player.play();
+      const promise = this.player.play();
+      if (promise) {
+        promise.catch(reason => console.log("VIDEOJS:", reason)).then(() => {});
+      }
     }
   }
 

--- a/src/components/video/file.js
+++ b/src/components/video/file.js
@@ -1,0 +1,55 @@
+import VideoPlayer from "./video_player";
+
+class File extends VideoPlayer {
+
+  initialize(options) {
+    this.player = null;
+    super.initialize(options);
+  }
+
+  setup() {
+    if (this.videoId) {
+      let html = "<video preload='auto' src='" + this.videoId + "' ";
+
+      if (this.controls) {
+        html += " controls ";
+      }
+
+      if (this.autoplay) {
+        html += " autoplay ";
+      }
+
+      if (this.poster) {
+        html += "poster='" + this.poster + "' ";
+      }
+
+      html += "></video>";
+
+      this.$el.html(html);
+
+      this.player = this.el.getElementsByTagName("video")[0];
+    }
+    super.setup();
+  }
+
+  play() {
+    super.play();
+    if (this.player) {
+      this.player.play();
+    }
+  }
+
+  pause() {
+    super.pause();
+    if (this.player) {
+      this.player.pause();
+    }
+  }
+
+  dispose() {
+    this.$el.html("");
+    super.dispose();
+  }
+}
+
+export default File;

--- a/src/components/video/index.js
+++ b/src/components/video/index.js
@@ -16,8 +16,10 @@ players.set("file", File)
   example usage:
 
     let player = null;
-    Video.addPlayer("video-elements-id", {autoplay: true}).then((x) => {player = x;});
-    player.on("ended", () => alert("video finished playing!")));
+    Video.addPlayer("element-id", {autoplay: true}).then((x) => {
+      player = x;
+      player.on("ended", () => alert("video finished playing!")));
+    });
 
   parameters:
 
@@ -31,11 +33,11 @@ players.set("file", File)
     playerName - (optional) "default", "bestintravel", "destinations", or "background".  This determines
           which player from the respective "type" to insert into the page. ("brightcove" only).
 
-    videoId - (optional) The id of the video to play.  This can be either an id
+    videoId - (optional) The id or URL of the video to play.  This can be either an id
           pertaining to the platform depicted by the 'type' parameter, or it can
-          be a URL to a video (which will be parsed internally to get the video id)
+          be a URL to a video (which will be parsed internally to get the video id if needed)
 
-    autoplay - (optional) whether the player should autoplay once it's ready/loaded
+    autoplay - (optional) Whether the player should autoplay once it's ready/loaded
 
     poster - (optional) URL to poster image to display before video begins
           playing ("file" only)
@@ -44,6 +46,10 @@ players.set("file", File)
 
     controls - (optional) Whether to include HTML5 video controls on the player or
           not ("brightcove" and "file" only)
+
+    popout - (optional) Whether the player should follow the user when it scrolls
+          out of view ("brightcove" only) -- Only works if the video embed does not
+          exist on the page prior to instantiation.
 
   events:
 
@@ -62,6 +68,7 @@ class Video {
     poster = null,
     controls = true,
     seo = true,
+    popout = false,
   } = {}) {
 
     if (typeof element === "string") {
@@ -101,6 +108,7 @@ class Video {
           controls,
           playerName,
           seo,
+          popout,
         });
 
     this.players.set(element, player);

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -2,10 +2,23 @@ import { Component } from "../../core/bane";
 
 class VideoPlayer extends Component {
 
-  initialize({ playerId, videoId = null, autoplay = false }) {
+  initialize({
+    playerId,
+    playerName = "default",
+    videoId = null,
+    autoplay = false,
+    poster = null,
+    controls = true,
+    seo = true, }) {
+
     this.playerId = playerId;
     this.videoId = videoId;
     this.autoplay = autoplay;
+    this.poster = poster;
+    this.playerName = playerName;
+    this.seo = seo;
+    this.controls = controls;
+
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
     this.isReady = false;
@@ -22,22 +35,36 @@ class VideoPlayer extends Component {
   }
 
   /**
-   * Override to actually kill the underlying player
+   * Kills the underlying player (removing it from the page and any references to it)
+   * Make sure this.trigger("disposed") is called within this function.
    */
   dispose() {
     this.trigger("disposed", this);
   }
 
   /**
-   * Override to actually play the underlying player
+   * Plays the underlying player
    */
   play() {
   }
 
   /**
-   * Override to actually pause the underlying player
+   * Similar to play(), but should be used when expecting to play through a series of videos.
+   */
+  start() {
+    this.play();
+  }
+
+  /**
+   * Pauses the underlying player
    */
   pause() {
+  }
+
+  /**
+   * Loads one or more videos into the players "video cache". (Currently only works with Brightcove)
+   */
+  fetchVideos() {
   }
 
 }

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -11,6 +11,9 @@ class VideoPlayer extends Component {
     controls = true,
     seo = true,
     popout = false,
+    cover = false,
+    muted = false,
+    playWhenInView = false,
   }) {
 
     this.playerId = playerId;
@@ -21,12 +24,26 @@ class VideoPlayer extends Component {
     this.seo = seo;
     this.controls = controls;
     this.popout = popout;
+    this.cover = cover;
+    this.muted = muted;
+    this.playWhenInView = playWhenInView;
 
     this.defaultAspectRatio = 1.77777778;
     this.events = {};
     this.isReady = false;
     this.on("ready", () => { this.isReady = true; });
     this.setup();
+  }
+
+  /**
+   * Use this to change any properties of the player after initialization.
+   * There is no default logic for this method as changing some properties may
+   * involve complex operations rather than simply changing the properties
+   * on the instance.
+   * Warning: This is implemented as needed and currently only covers "autoplay"
+   * and "videoId" on Brightcove players.
+   */
+  set(options) {
   }
 
   /**

--- a/src/components/video/video_player.js
+++ b/src/components/video/video_player.js
@@ -9,7 +9,9 @@ class VideoPlayer extends Component {
     autoplay = false,
     poster = null,
     controls = true,
-    seo = true, }) {
+    seo = true,
+    popout = false,
+  }) {
 
     this.playerId = playerId;
     this.videoId = videoId;
@@ -18,6 +20,7 @@ class VideoPlayer extends Component {
     this.playerName = playerName;
     this.seo = seo;
     this.controls = controls;
+    this.popout = popout;
 
     this.defaultAspectRatio = 1.77777778;
     this.events = {};

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -10,7 +10,9 @@ class Youtube extends VideoPlayer {
       if (this.autoplay) {
         html += "?autoplay=1";
       }
-      html += "' frameborder='0' allowfullscreen></iframe>";
+      html += "' frameborder='0' allowfullscreen ";
+
+      html += "></iframe>";
 
       this.$el.html(html);
     }

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -10,9 +10,7 @@ class Youtube extends VideoPlayer {
       if (this.autoplay) {
         html += "?autoplay=1";
       }
-      html += "' frameborder='0' allowfullscreen ";
-
-      html += "></iframe>";
+      html += "' frameborder='0' allowfullscreen ></iframe>";
 
       this.$el.html(html);
     }

--- a/src/components/video/youtube.js
+++ b/src/components/video/youtube.js
@@ -14,12 +14,12 @@ class Youtube extends VideoPlayer {
 
       this.$el.html(html);
     }
-    this.trigger("ready");
+    super.setup();
   }
 
   dispose() {
     this.$el.html("");
-    this.trigger("disposed", this);
+    super.dispose();
   }
 }
 

--- a/src/components/video_poster_button/_video_poster_button.scss
+++ b/src/components/video_poster_button/_video_poster_button.scss
@@ -29,11 +29,11 @@
     top: 0;
     transition: opacity $animation-speed-ui ease-in-out;
     width: 100%;
-    z-index: -20;
+    z-index: 0;
 
     &--visible {
       opacity: 1;
-      z-index: 0;
+      z-index: z("top");
     }
   }
 
@@ -45,11 +45,11 @@
     overflow: hidden;
     position: relative;
     transition: opacity $animation-speed-ui ease-in-out;
-    z-index: -20;
+    z-index: 0;
 
     &--visible {
       opacity: 1;
-      z-index: 0;
+      z-index: 1;
     }
 
     img {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -12,7 +12,9 @@ export default class VideoPosterButtonComponent extends Component {
         "click .video-poster-button__inner": "onClick"
     };
 
-    Video.addPlayer(this.$el.find(".video-poster-button__video")[0]).then(this.playerReady.bind(this));
+    Video.addPlayer(
+      this.$el.find(".video-poster-button__video")[0],
+      { popout: true }).then(this.playerReady.bind(this));
   }
 
   showVideo() {

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -51,13 +51,15 @@ export default class VideoPosterButtonComponent extends Component {
   }
 
   renderImage() {
-    let image = null;
+    let image = this.player.poster;
 
-    try {
-        const mediainfo = this.player.player.mediainfo;
-        image = mediainfo.poster;
-    }
-    catch (e) {
+    if (!image) {
+      try {
+          const mediainfo = this.player.player.mediainfo;
+          image = mediainfo.poster;
+      }
+      catch (e) {
+      }
     }
 
     if (!image) {
@@ -99,7 +101,16 @@ export default class VideoPosterButtonComponent extends Component {
   playerReady(player) {
     this.player = player;
     this.listenTo(this.player, "ended", this.onPlayerEnded.bind(this));
-    this.listenTo(this.player, "loadstart", this.onPlayerLoadStart.bind(this));
+
+    // If the player has a poster configured on it, we can render the poster button now
+    if (this.player.poster) {
+      this.render();
+    }
+    else {
+      // We need to wait until the player has mediainfo before we can get the poster image
+      this.listenTo(this.player, "loadstart", this.onPlayerLoadStart.bind(this));
+    }
+
     this.player.fetchVideos();
   }
 

--- a/src/components/video_poster_button/video_poster_button_component.js
+++ b/src/components/video_poster_button/video_poster_button_component.js
@@ -12,9 +12,7 @@ export default class VideoPosterButtonComponent extends Component {
         "click .video-poster-button__inner": "onClick"
     };
 
-    Video.addPlayer(
-      this.$el.find(".video-poster-button__video")[0],
-      { popout: true }).then(this.playerReady.bind(this));
+    Video.addPlayer(this.$el.find(".video-poster-button__video")[0]).then(this.playerReady.bind(this));
   }
 
   showVideo() {


### PR DESCRIPTION
1. Added `File` video type for general file video sources (embeds a simple `video` tag).
2. Add the following parameters to rizzo's video component:

    `playerName` - (optional) "default", "bestintravel", "destinations", or "background".  This determines
          which player from the respective "type" to insert into the page. ("brightcove" only).

    `poster` - (optional) URL to poster image to display before video begins
          playing ("file" only)

    `seo` - (optional) Whether to render SEO markup for the video ("brightcove" only)

    `controls` - (optional) Whether to include HTML5 video controls on the player or
          not ("brightcove" and "file" only)

    `popout` - (optional) Whether the player should follow the user when it scrolls
          out of view ("brightcove" only) -- Only works if the video embed does not
          exist on the page prior to instantiation.

    `cover` - (optional) Whether to cover the entire parent element with the
          video -- acts similar to background-size css. ("file" and "brightcove" only).

    `muted` - (optional) Whether the video should be muted or not ("file" and "brightcove" only).

    `playWhenInView` - (optional) Whether to play the video automatically once the
          player enters the viewport.  This will only trigger once during the lifetime of
          the player instance. ("brightcove" only).


Usage in masthead of BIT page:
<img width="851" alt="screen shot 2017-10-03 at 10 26 46 am" src="https://user-images.githubusercontent.com/3586751/31130656-f4875f7c-a825-11e7-8b0f-733dbfa27a27.png">

Popout player (stays at 16:9 -- the video in the screenshot isn't 16:9 but it's just a test video):
<img width="1003" alt="screen shot 2017-10-03 at 10 27 08 am" src="https://user-images.githubusercontent.com/3586751/31130668-ff7a5dd0-a825-11e7-9dc0-5d70da78afb5.png">

Popout player (hover):
<img width="474" alt="screen shot 2017-10-03 at 10 27 15 am" src="https://user-images.githubusercontent.com/3586751/31130690-13e6da78-a826-11e7-85c6-da05294f6982.png">
