### PR TITLE
fix: Exclude paragraphs that look like headings from in-article ads

### DIFF
--- a/src/components/article/article_component.js
+++ b/src/components/article/article_component.js
@@ -22,7 +22,7 @@ export default class ArticleComponent extends Component {
 
     const paragraphs = $articleBody.find("p")
       .filter((index, p) => {
-        return !$(p).attr("class") || $(p).attr("class") === "feature" ;
+        return (!$(p).attr("class") || $(p).attr("class") === "feature") && !$(p).has(".copy--body__strong").length;
       });
 
     $(paragraphs).each((index, p) => {


### PR DESCRIPTION
https://github.com/lonelyplanet/destinations-next/issues/1426