### PR TITLE
Removed playsinline from brightcove video embeds

### DIFF
--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -203,7 +203,7 @@ class Brightcove extends VideoPlayer {
               data-account="${this.bcAccountId}"
               data-player="${this.bcPlayerId}"
               data-embed="${this.bcEmbedId}"
-              data-application-id class="video-js" playsinline ></video>
+              data-application-id class="video-js" ></video>
             <div class='video__muted-overlay'><span class='vjs-icon-volume-high' /></div>
           </div>
         </div>`;


### PR DESCRIPTION
This was pushed out yesterday to see if we could force iphone 5 to play video "inline" instead of in a native takeover.  It "kind of" works but it feels terrible and is a bad user experience.