### PR TITLE
Brightcove video component will now bind to pre-existing video element if not videoId is supplied

### DIFF
--- a/src/components/article_body/article_body.js
+++ b/src/components/article_body/article_body.js
@@ -55,7 +55,6 @@ export default class ArticleBodyComponent extends Component {
       .addClass("is-visible")
       .each((i, el) => {
         Video.addPlayer(el, {
-          playerName: "article",
           insertPixel: false,
         }).then((player) => {
           const description = player.getVideoProperty("description") || "";

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -8,7 +8,6 @@ const _ = { get };
 
 const bcPlayerIds = {
   default: "default",
-  article: "S1T3jIHnZ",
   background: "BJputewob",
   bestintravel: "HkJcclwoZ",
   destination: "HkPdqeDiZ",

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -190,10 +190,7 @@ class Brightcove extends VideoPlayer {
   }
 
   setup() {
-    if (!this.videoId) {
-      this.trigger("ready");
-    }
-    else if (!this.videoEl) {
+    if (!this.videoEl) {
       let html = `
         <div class="video__popout ${MobileUtil.isMobile() ? "video__popout-mobile" : ""}">
           <div class="video__popout-inner video__popout-inner-visible ${this.cover ? "video__cover--container" : ""}">


### PR DESCRIPTION
On article pages, the video embed already exists with a video loaded in it.  Our Brightcove component only needs to bind to it and doesn't need to know the videoId (which old logic was basically preventing the component from doing anything without a supplied videoId -- I believe I put that in there with the assumption that if a video embed is pre-existing, we assume that we don't need to muck with it programmatically;  This is not the case anymore).

Removed the `article` playerName option because it is not used -- it never was; I put that in by mistake.

The new code works everywhere where we have brightcove video.