### PR TITLE
Removed watch later from user panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6789,7 +6789,7 @@
     "inversify": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.3.0.tgz",
-      "integrity": "sha512-BbKzOP4nLl7DSHx31vN5KgUkkJc759+OLocDGryldXPjogixzOs/n4qvT25lbNN67uB6aWlFF84NS/zI5j8pfg=="
+      "integrity": "sha1-0uzSrhg0Dn8atRSKPkS4cIA5E2Y="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -10415,7 +10415,7 @@
     "rc-animate": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.1.tgz",
-      "integrity": "sha512-hixobyAvDv0Oz4gHPOh67K4ck5Rz3JBBojBuKzYcu4b8JKMIiJxym83DfkkkYxXEEx/rwGf0mU0Dno/lbWghIQ==",
+      "integrity": "sha1-3z4PVv4Qav5L9S/0CM7SQcUXiRk=",
       "requires": {
         "babel-runtime": "6.25.0",
         "css-animation": "1.3.2",
@@ -10447,7 +10447,7 @@
     "rc-trigger": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-1.11.3.tgz",
-      "integrity": "sha512-g5Y2TxMB44Ubg2qpj0Qj9NTT+/jWysv2yKPgDe1CqvKbIxiM+3fVkl04u4ppXMNpN3qi6zWqKzugFcfdG6at4A==",
+      "integrity": "sha1-R7i1jghjwid+NnuG8c+inrYS21Y=",
       "requires": {
         "babel-runtime": "6.25.0",
         "create-react-class": "15.6.0",
@@ -10541,7 +10541,7 @@
     "react-modal": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-1.9.7.tgz",
-      "integrity": "sha512-oZNqI0ZnPD7NnfObrCMz2hxHTAw5oEuhZJ+gnyFNIQB2rR8h1YbLQTfhms1mtSJigb0J23OOWElHjXYYaKO+wg==",
+      "integrity": "sha1-B+9WeQuVPjuY7x4pieNHmDxyhx0=",
       "requires": {
         "create-react-class": "15.6.0",
         "element-class": "0.2.2",
@@ -10561,7 +10561,7 @@
     "react-moment-proptypes": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/react-moment-proptypes/-/react-moment-proptypes-1.5.0.tgz",
-      "integrity": "sha512-0dQJNs0aaiMeGp1AJACDTzGMM7N4qv4Wgg1948/ARdLt3VKlkcem6Yjm5ExUmUtoXk6WpSXvFQ204l7E+RTEEQ==",
+      "integrity": "sha1-SkSM1kee/F3VCSg/Nh83U8Or5g4=",
       "requires": {
         "moment": "2.18.1"
       }
@@ -10590,7 +10590,7 @@
     "react-photoswipe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-photoswipe/-/react-photoswipe-1.3.0.tgz",
-      "integrity": "sha512-1ok6vXFAj/rd60KIzF0YwCdq1Tcl+8yKqWJHbPo43lJBuwUi+LBosmBdJmswpiOzMn2496ekU0k/r6aHWQk7PQ==",
+      "integrity": "sha1-AW3ZeEUKhAZ3bbl1Eer5by/7nPs=",
       "requires": {
         "classnames": "2.2.5",
         "lodash.pick": "4.4.0",
@@ -10667,7 +10667,7 @@
     "react-scroll": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.5.4.tgz",
-      "integrity": "sha512-dK6560l7Js0JoVV6hdoTQmMnpE2Nkv5gJZgZlBuu2tGTnhgqR62OQ8GE2zNG0NyKB5YREK1hpeVqHDixad+pYw==",
+      "integrity": "sha1-jFxM7WWVU74fo5lZd2yFBV/OsTc=",
       "requires": {
         "object-assign": "4.1.1",
         "prop-types": "15.5.10"
@@ -10685,7 +10685,7 @@
         "shallowequal": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.0.2.tgz",
-          "integrity": "sha512-zlVXeVUKvo+HEv1e2KQF/csyeMKx2oHvatQ9l6XjCUj3agvC8XGf6R9HvIPDSmp8FNPvx7b5kaEJTRi7CqxtEw=="
+          "integrity": "sha1-FWHb3vuMAUCBADGQhXZNo/z4P48="
         }
       }
     },

--- a/src/components/navigation/user_panel.hbs
+++ b/src/components/navigation/user_panel.hbs
@@ -8,7 +8,7 @@
     <li class="sub-navigation__item">
        <a class="sub-navigation__link" href="{{user.publicProfileLink}}">Profile</a>
     </li>
-    
+
     <li class="sub-navigation__item">
        <a class="sub-navigation__link" href="{{user.publicProfileLink}}/lists">Lists</a>
     </li>
@@ -20,10 +20,6 @@
 
     <li class="sub-navigation__item">
       <a class="sub-navigation__link" href="https://www.lonelyplanet.com/thorntree/messages">Messages</a>
-    </li>
-
-    <li class="sub-navigation__item">
-      <a class="sub-navigation__link" href="https://www.lonelyplanet.com/video?watchLaterModal=open">Watch Later</a>
     </li>
 
     <li class="sub-navigation__item">

--- a/src/components/video/brightcove.js
+++ b/src/components/video/brightcove.js
@@ -630,16 +630,20 @@ class Brightcove extends VideoPlayer {
       return;
     }
 
-    const overlays = this.player.mediainfo.cuePoints.map((cue) => {
-      const defaultEnd = cue.startTime + 15;
-      const end = defaultEnd < cue.endTime ? defaultEnd : cue.endTime;
+    const overlayCuePoints = this.player.mediainfo.cuePoints
+      .filter((cuePoint) => cuePoint.type === "CODE")
+      .filter((cuePoint) => cuePoint.name !== "preview start" && cuePoint.name !== "preview end");
 
-      const cueElementId = `ad-lowerthird-${this.playerId}-${cue.id}`;
+    const overlays = overlayCuePoints.map((cuePoint) => {
+      const defaultEnd = cuePoint.startTime + 15;
+      const end = defaultEnd < cuePoint.endTime ? defaultEnd : cuePoint.endTime;
+
+      const cueElementId = `ad-lowerthird-${this.playerId}-${cuePoint.id}`;
 
       return {
         content: `<div id="${cueElementId}" class="video__lowerthird-overlay" />`,
         align: "bottom",
-        start: cue.startTime,
+        start: cuePoint.startTime,
         end,
       };
     });


### PR DESCRIPTION
1. Watch Later is being removed as we launch the redesigns video hub today until Bookmarks can be implemented for video.

2. `preview start` and `preview end` are special names we will be giving to cue points in brightcove that will be used to configure the timeframe that should loop within a video when a video is used as the background (like the background video in the masthead for BiT for example).   So these are skipped so that our player doesn't think that they are cue points for lower third ads.