### PR TITLE
Delete .eot font embeds

### DIFF
--- a/sass/generic/_fonts.scss
+++ b/sass/generic/_fonts.scss
@@ -12,6 +12,7 @@
   font-style: normal;
   font-stretch: normal;
   font-weight: 300; // Light
+  font-display: swap;
 }
 
 @font-face {
@@ -21,6 +22,7 @@
   font-style: normal;
   font-stretch: normal;
   font-weight: 500; // Regular
+  font-display: swap;
 }
 
 @font-face {
@@ -30,6 +32,7 @@
   font-style: normal;
   font-stretch: normal;
   font-weight: 600; // Medium
+  font-display: swap;
 }
 
 @font-face {
@@ -39,6 +42,7 @@
   font-style: normal;
   font-stretch: normal;
   font-weight: 400;
+  font-display: swap;
 }
 
 @font-face {
@@ -48,4 +52,5 @@
   font-style: italic;
   font-stretch: normal;
   font-weight: 400;
+  font-display: swap;
 }

--- a/sass/generic/_fonts.scss
+++ b/sass/generic/_fonts.scss
@@ -7,9 +7,7 @@
 
 @font-face {
   font-family: "Benton Sans";
-  src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-3.woff") format("woff"),
+  src: url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/2c8c3478-e1ba-4af3-bfd0-9fea259fc17f-1.ttf") format("truetype");
   font-style: normal;
   font-stretch: normal;
@@ -18,9 +16,7 @@
 
 @font-face {
   font-family: "Benton Sans";
-  src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-3.woff") format("woff"),
+  src: url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/19319132-31a6-45e2-85a5-6dacae897490-1.ttf") format("truetype");
   font-style: normal;
   font-stretch: normal;
@@ -29,9 +25,7 @@
 
 @font-face {
   font-family: "Benton Sans";
-  src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-3.woff") format("woff"),
+  src: url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/743d3d3a-da58-48d2-a5c3-bd7994650e23-1.ttf") format("truetype");
   font-style: normal;
   font-stretch: normal;
@@ -40,9 +34,7 @@
 
 @font-face {
   font-family: "Miller Daily";
-  src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-3.woff") format("woff"),
+  src: url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/6e603ae4-800b-4625-9fa8-1819315263a6-1.ttf") format("truetype");
   font-style: normal;
   font-stretch: normal;
@@ -51,9 +43,7 @@
 
 @font-face {
   font-family: "Miller Daily";
-  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot");
-  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-2.eot?") format("embedded-opentype"),
-       url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-3.woff") format("woff"),
+  src: url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-3.woff") format("woff"),
        url("https://assets.staticlp.com/javascripts/2d4b6287-e087-4bce-89af-61a0cd634f27-1.ttf") format("truetype");
   font-style: italic;
   font-stretch: normal;


### PR DESCRIPTION
.eot font files are specifically used for IE 6 - 11 and we don’t
support IE below 11, so they are no longer needed.

.woff has support pretty good support across the board; from IE 9 and
up and all of Edge, but no support in Android 4.3 and below.

.ttf files have the overall best support for legacy browsers,
specifically for Android 4.3 and below. I’m not sure what our support
for legacy Android is, so .ttf remains. However, if we feel fine serving
a non-custom font to legacy Android, then we can remove .ttf.

I would like to see if we can get a .woff2 version of our fonts. The
file sizes are much smaller on average and support is pretty good.
Ideally we would only load .woff and .woff2 files.