### PR TITLE
feat: Changed styles for the newly added articles list

### DIFF
--- a/src/components/article/article.hbs
+++ b/src/components/article/article.hbs
@@ -38,6 +38,4 @@
       </footer>
     </div>
   </div>
-
-  {{> "components/ads/ad_article_leaderboard" }}
 </article>

--- a/src/components/article/article.scss
+++ b/src/components/article/article.scss
@@ -13,7 +13,6 @@
 /// ----------------------------------------------------------------------------
 
 .article {
-  border-bottom: .1rem solid $color-gray;
   opacity: 1;
   overflow: hidden; // Prevent horizontal movement in iOS caused by .size-full images
   position: relative;
@@ -37,6 +36,7 @@
 
 .article__container {
   @include container-padded;
+  border-bottom: .1rem solid $color-gray;
   padding-bottom: gutter(static);
   padding-top: 4.4rem;
   position: relative;

--- a/src/components/article_body/article_body.scss
+++ b/src/components/article_body/article_body.scss
@@ -86,6 +86,7 @@
       padding-left: 2rem;
     }
 
+    .copy--h2,
     .copy--h3,
     .copy--h4 {
       color: $darkgray;
@@ -93,6 +94,11 @@
       letter-spacing: -.02rem;
       margin-bottom: 1rem;
       margin-top: 2.5rem;
+    }
+
+    .copy--h2 {
+      font-size: 2.7rem;
+      line-height: (28 / 18);
     }
 
     .copy--h3 {


### PR DESCRIPTION
This code:

* [Issue #1528](https://github.com/lonelyplanet/destinations-next/issues/1528)
  * Adds the same general style to the `h2` tags that the `h3` and `h4` tags have
  * Specifies the font size and line height for the `h2` tags
* [Issue #1523](https://github.com/lonelyplanet/destinations-next/issues/1523)
  * Removes the ad from the bottom of the article page (since it will be relocated to under the articles list)
  * Changes the article's bottom border in preparation for the articles list 