### PR TITLE
fix: reallow basic text search from nav

### DIFF
--- a/spec/unit/components/header.spec.js
+++ b/spec/unit/components/header.spec.js
@@ -1,7 +1,13 @@
 import $ from "jquery";
 let Injector = require("inject-loader!../../../src/components/header/header_component");
 
+let showSearchCalled = 0;
+
+let SearchMock = function() {};
+SearchMock.prototype = { show: function() { ++showSearchCalled; } };
+
 let Header = Injector({
+  "../search": SearchMock,
   "../navigation": function() {}
 }).default;
 
@@ -26,4 +32,11 @@ describe("header", () => {
     // Cleanup
     Header.prototype.isTooBig = isTooBig;
   });
+});
+
+it("should show the search when clicked", () => {
+  let $el = $(html);
+  let header = new Header({ el: $el });
+   $el.find(".js-lp-global-header-search").eq(0).trigger("click");
+   expect(showSearchCalled).to.be(1);
 });

--- a/src/components/header/header_component.js
+++ b/src/components/header/header_component.js
@@ -1,6 +1,7 @@
 import $ from "jquery";
 import debounce from "lodash/debounce";
 import { Component } from "../../core/bane";
+import SearchComponent from "../search";
 import NavigationComponent from "../navigation";
 import NavigationState from "../navigation/navigation_state";
 
@@ -13,7 +14,7 @@ class Header extends Component {
 
   initialize() {
     this.state = NavigationState.getState();
-
+    this.search = new SearchComponent();
     this.navigation = new NavigationComponent({
       el: $(".navigation")
     });
@@ -61,6 +62,12 @@ class Header extends Component {
    */
   isTooBig() {
     return this.$search.width() > this.$inner.width() * .42;
+  }
+
+  onSearchClick(e) {
+    e.preventDefault();
+
+    this.search.show();
   }
 
   onMobileMenuClick(e){


### PR DESCRIPTION
The search bar overlay was at one point working but then deactivated. My
best understanding was that it was the result of autocomplete not
working. Reimplementing without autocomplete to allow a user to make a
search query from anywhere on the site without having to drill down into
the search page first.