### PR TITLE
chore: excise lp-analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -234,17 +234,6 @@
         }
       }
     },
-    "@lonelyplanet/lp-analytics": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/@lonelyplanet/lp-analytics/-/lp-analytics-2.0.9.tgz",
-      "integrity": "sha512-E0uaxktmTgNWLDx5NF1plh6U9d64IWzHsWS+rbtXQsDvcAV8/2wrvXqQ/q3O6FCpjkzX6yIGV9hC9awwkTpy6Q==",
-      "requires": {
-        "@types/react": "^16.4.18",
-        "@types/react-dom": "^16.0.9",
-        "devalue": "^1.0.4",
-        "react-helmet": "^5.2.0"
-      }
-    },
     "@lonelyplanet/open-planet-node": {
       "version": "2.24.8",
       "resolved": "https://registry.npmjs.org/@lonelyplanet/open-planet-node/-/open-planet-node-2.24.8.tgz",
@@ -256,34 +245,6 @@
         "pluralize": "^5.0.0",
         "reflect-metadata": "^0.1.10",
         "request": "^2.81.0"
-      }
-    },
-    "@types/node": {
-      "version": "10.12.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.3.tgz",
-      "integrity": "sha512-sfGmOtSMSbQ/AKG8V9xD1gmjquC9awIIZ/Kj309pHb2n3bcRAcGMQv5nJ6gCXZVsneGE4+ve8DXKRCsrg3TFzg=="
-    },
-    "@types/prop-types": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
-      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
-    },
-    "@types/react": {
-      "version": "16.4.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.18.tgz",
-      "integrity": "sha512-eFzJKEg6pdeaukVLVZ8Xb79CTl/ysX+ExmOfAAqcFlCCK5TgFDD9kWR0S18sglQ3EmM8U+80enjUqbfnUyqpdA==",
-      "requires": {
-        "@types/prop-types": "*",
-        "csstype": "^2.2.0"
-      }
-    },
-    "@types/react-dom": {
-      "version": "16.0.9",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.0.9.tgz",
-      "integrity": "sha512-4Z0bW+75zeQgsEg7RaNuS1k9MKhci7oQqZXxrV5KUGIyXZHHAAL3KA4rjhdH8o6foZ5xsRMSqkoM5A3yRVPR5w==",
-      "requires": {
-        "@types/node": "*",
-        "@types/react": "*"
       }
     },
     "JSONStream": {
@@ -3206,11 +3167,6 @@
         "source-map": "^0.5.3"
       }
     },
-    "csstype": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3301,11 +3257,6 @@
           "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
         }
       }
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -3447,11 +3398,6 @@
         "acorn": "^5.2.1",
         "defined": "^1.0.0"
       }
-    },
-    "devalue": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-1.1.0.tgz",
-      "integrity": "sha512-mKj+DaZuxevfmjI78VdlkBr+NDmwaDAKQz0t5RDSmhwBn6m5z82KDnVRKVFeUvlMOmI1fzkAUx4USdqGGhas6g=="
     },
     "di": {
       "version": "0.0.1",
@@ -4645,6 +4591,11 @@
       "requires": {
         "locate-path": "^2.0.0"
       }
+    },
+    "flamsteed": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/flamsteed/-/flamsteed-0.0.4.tgz",
+      "integrity": "sha1-Lhy7SPvSkmj0YYiyfHIZjY1QQs4="
     },
     "flat-cache": {
       "version": "1.3.0",
@@ -10071,17 +10022,6 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.0"
-      }
-    },
-    "react-helmet": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.2.0.tgz",
-      "integrity": "sha1-qBgR3yExOm1VxfBYxK66XW89l6c=",
-      "requires": {
-        "deep-equal": "^1.0.1",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.5.4",
-        "react-side-effect": "^1.1.0"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   ],
   "dependencies": {
     "@lonelyplanet/dotcom-core": "^2.0.3",
-    "@lonelyplanet/lp-analytics": "^2.0.9",
     "airbrake-js": "^0.9.3",
     "async": "^2.0.0-rc.4",
     "aws-sdk": "^2.155.0",

--- a/src/components/footer/footer_component.js
+++ b/src/components/footer/footer_component.js
@@ -1,10 +1,8 @@
 import { Component } from "../../core/bane";
-import { analytics, EventNames, getTrackMethod } from "@lonelyplanet/lp-analytics";
 import $ from "jquery";
 
 class Footer extends Component {
   initialize() {
-    this.track = getTrackMethod();
     this.updateLocationOnChange();
     this.$form = $(".js-newsletter-form");
     this.$form.on("submit", this.submit.bind(this));
@@ -24,9 +22,10 @@ class Footer extends Component {
   handleSubmitSuccess() {
     this.$form.addClass("is-hidden");
     this.$success.removeClass("is-hidden");
-    this.track({
-      [analytics.eventName]: EventNames.newsletterSubscription,
-    });
+    if (typeof window !== "undefined" && window.dataLayer && Array.isArray(window.dataLayer)) {
+      // shim for lp-analytics; importing the module seems to break rizzo (not this, rizzo-next, but legacy rizzo, which imports this)
+      window.dataLayer.push({ event: "newsletter-subscribe" });
+    }
   }
 
   submit(event) {

--- a/src/components/modal/modal_component.js
+++ b/src/components/modal/modal_component.js
@@ -1,4 +1,3 @@
-import { analytics, EventNames, getTrackMethod } from "@lonelyplanet/lp-analytics";
 import { Component } from "../../core/bane";
 import waitForTimeout from "../../core/utils/waitForTransition";
 import Overlay from "../overlay";
@@ -8,7 +7,6 @@ import SocialShareComponent from "../social_share";
 
 class Modal extends Component {
   initialize(options) {
-    this.track = getTrackMethod();
     this.events = {
       "touchend a": "goTo"
     };
@@ -142,9 +140,10 @@ class Modal extends Component {
      * I don't know if it's still in use (the file in the PR above has since been deleted),
      * but just in case, tracking here as well.
      */
-    this.track({
-      [analytics.eventName]: EventNames.newsletterSubscription,
-    });
+    if (typeof window !== "undefined" && window.dataLayer && Array.isArray(window.dataLayer)) {
+      // shim for lp-analytics; importing the module seems to break rizzo (not this, rizzo-next, but legacy rizzo, which imports this)
+      window.dataLayer.push({ event: "newsletter-subscribe" });
+    }
   }
 
   submit(e) {


### PR DESCRIPTION
`rizzo` imports `rizzo-next`, but doesn't have access to all of its submodules, I suppose.

Since its runs across `lp-analytics` in the process of building out the head js & footer, it tries to import the module, but can't find it.

I think it could probably be made to work by importing `lp-analytics` via bower/require-js in `rizzo`, but I tbh don't know enough about how those differing module systems work to feel confident that I could resolve the issue quickly enough.

This is the hack solution-- do the same thing that `lp-analytics` is supposed to do for us.

(using `window.dataLayer` will work-- `lp-analytics` will be invoked through other means on the host page, and `window.dataLayer` will either alias to `window.lp.analytics.dataLayer` or it will itself be the source of truth for gtm content).