### PR TITLE
update z-index for destinations-next map

### DIFF
--- a/sass/settings/_z-index.scss
+++ b/sass/settings/_z-index.scss
@@ -6,7 +6,7 @@ $z-index: (
   "middle": 10,
   "top": 20,
   "global-header": 100,
-  "map-holder-open": 200,
+  "map-holder-open": 3000,
   "video-overlay-close": 1000,
   "popup": 4000,
   "dialog": 5000,


### PR DESCRIPTION
new global header has `z-index=2000`, we need to increase this to get rid of global header in front of destinations-next maps (see below)