### PR TITLE
fix: replaces a deprecated function to prevent error

### DIFF
--- a/src/components/map/views/sidebar-details.jsx
+++ b/src/components/map/views/sidebar-details.jsx
@@ -3,11 +3,16 @@ import MapActions from "../actions";
 import $clamp from "clamp-js/clamp.js";
 
 export default class SidebarDetailsView extends React.Component{
-  componentDidMount() {
-    let el = this.refs.poiTitle.getDOMNode();
+  constructor(props) {
+    super(props);
 
-    $clamp(el, { clamp: 2 });
+    this.setPoitTitleRef = el => this.poiTitle = el;
+
   }
+  componentDidMount() {
+    $clamp(this.poiTitle, { clamp: 2 });
+  }
+
   render() {
     let poi = this.props.poi,
         image = "",
@@ -27,7 +32,7 @@ export default class SidebarDetailsView extends React.Component{
       <div className="sidebar details">
         <header className="sidebar__header">
           <a href="#" className="close-poi location-subtitle" onClick={this.closePOI}><i className="icon icon-chevron-left" aria-hidden="true"></i>Back</a>
-          <h1 ref="poiTitle" className="sidebar__title">
+          <h1 ref={this.setPoitTitleRef} className="sidebar__title">
             {poi.title}
           </h1>
         </header>


### PR DESCRIPTION
 getDOMNode is no longer supported and calling it causes an uncaught error