### PR TITLE
fix: clean dfp strings of special characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14110,7 +14110,7 @@
     "react-photoswipe": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-photoswipe/-/react-photoswipe-1.3.0.tgz",
-      "integrity": "sha512-1ok6vXFAj/rd60KIzF0YwCdq1Tcl+8yKqWJHbPo43lJBuwUi+LBosmBdJmswpiOzMn2496ekU0k/r6aHWQk7PQ==",
+      "integrity": "sha1-AW3ZeEUKhAZ3bbl1Eer5by/7nPs=",
       "requires": {
         "classnames": "^2.2.3",
         "lodash.pick": "^4.2.1",

--- a/src/core/utils/stringHelpers.js
+++ b/src/core/utils/stringHelpers.js
@@ -1,14 +1,20 @@
+import deburr from "lodash/deburr";
 /**
  * Takes a given string and turns it into a hyphenated slug
  * @param  {String} string String to replace
  * @return {String}
  */
-let slugify = (string) => {
+const clean = string => {
+  // allow only basic latin alpha, numeric, / - _ and whitespace
+  return deburr(string).replace(/[^/-\w\s]/gi, "");
+};
+
+let slugify = string => {
   if (!string || typeof string !== "string") return "";
 
-  return string.toLowerCase().replace(/\s/g, "-");
+  return clean(string)
+    .toLowerCase()
+    .replace(/\s/g, "-");
 };
 
-export {
-  slugify
-};
+export { slugify };


### PR DESCRIPTION
Google ads are very particular about which special characters are
allowed and which are not. Many of our place names contain special latin
characters, commas or parentheses. Clean these before slugifying and
passing to DFP as key values. This will fix an issue with two places in
the upcoming BiT campaign that should be targeted.