### PR TITLE
do not render footer component anymore

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -22,7 +22,6 @@ window.lp.ads = window.lp.ads || {};
 window.lp.ads.manager = new AdManager(window.lp.ads).initialize();
 
 rizzo.renderComponent(GlobalHeader, ".lp-global-header");
-rizzo.renderComponent(GlobalFooter, ".lp-global-footer");
 
 FastClick.attach(document.body);
 


### PR DESCRIPTION
Because we [completely removed footer component](https://github.com/lonelyplanet/rizzo-next/pull/877/files#diff-601970a029398d6038a7343ed14b78e89557d432c24e6b73c65124827405b8de) we should not render it anymore otherwise it'll throw `Uncaught TypeError: Component is not a constructor`:

<img width="506" alt="Screen Shot 2020-11-09 at 13 37 10" src="https://user-images.githubusercontent.com/5850443/98723678-02425b80-2393-11eb-86f5-c0dfb4665c5d.png">
