### PR TITLE
Resolve linting warnings

### DIFF
--- a/src/common.js
+++ b/src/common.js
@@ -1,7 +1,6 @@
 import "./components/analytics";
 import rizzo from "rizzo-next";
 import GlobalHeader from "./components/header";
-import GlobalFooter from "./components/footer";
 import FastClick from "fastclick";
 import "./core/utils/preload";
 import "./core/utils/detect_swipe";

--- a/src/components/search/search_component.js
+++ b/src/components/search/search_component.js
@@ -1,7 +1,7 @@
 import { Component } from "../../core/bane";
 import Overlay from "../overlay";
 import waitForTransition from "../../core/utils/waitForTransition";
-import SearchActions from "./search_actions";
+// import SearchActions from "./search_actions";
 import SearchState from "./search_state";
 import template from "./search.hbs";
 


### PR DESCRIPTION
This resolves the lint warnings due to a 3-year-old todo: and a missed import when the footer was removed.